### PR TITLE
feat: Adding an option for verbose device dumping

### DIFF
--- a/Buttplug.Components.Controls/ButtplugTabControl.xaml
+++ b/Buttplug.Components.Controls/ButtplugTabControl.xaml
@@ -22,8 +22,17 @@
 			</TabItem>
 			<TabItem Name="DeveloperTab" Header="Developer" Visibility="Collapsed">
 				<Grid Background="#FFE5E5E5">
-					<Button Content="Crash Application" Margin="10,10,0,232" HorizontalAlignment="Left" Click="CrashButton_Click" Width="108" Height="30"/>
-					<Button Content="Send Logs" Margin="10,56,0,186" HorizontalAlignment="Left" Click="SendLogsButton_Click" Width="108" Height="30"/>
+					<Grid.RowDefinitions>
+						<RowDefinition Height="auto"/>
+						<RowDefinition Height="auto"/>
+						<RowDefinition Height="auto"/>
+					</Grid.RowDefinitions>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto"/>
+					</Grid.ColumnDefinitions>
+					<Button Grid.Row="0" Margin="10,10,0,0" Content="Crash Application" Click="CrashButton_Click"/>
+					<Button Grid.Row="1" Margin="10,10,0,0" Content="Send Logs" Click="SendLogsButton_Click"/>
+					<Button Grid.Row="2" Margin="10,10,0,0" Content="Enable verbose device information" Click="DumpDevicesButton_Click"/>
 				</Grid>
 			</TabItem>
 		</TabControl>

--- a/Buttplug.Components.Controls/ButtplugTabControl.xaml.cs
+++ b/Buttplug.Components.Controls/ButtplugTabControl.xaml.cs
@@ -229,6 +229,22 @@ namespace Buttplug.Components.Controls
             _ravenClient?.Capture(new SentryEvent(string.Join("\n", LogControl.GetLogs())));
         }
 
+        private void DumpDevicesButton_Click(object aSender, RoutedEventArgs aEvent)
+        {
+            var res = _deviceManager?.SetVersoseDeviceLogging(((Button)aSender).Content.ToString() == "Enable verbose device information");
+            if (res == null)
+            {
+                return;
+            }
+
+            if (!res.Value)
+            {
+                ((Button)aSender).Content = "Enable verbose device information";
+            }
+
+            ((Button)aSender).Content = "Disable verbose device information";
+        }
+
         public void SetApplicationTab(string aTabName, UserControl aTabControl)
         {
             ApplicationTab.Header = aTabName;

--- a/Buttplug.Server/DeviceManager.cs
+++ b/Buttplug.Server/DeviceManager.cs
@@ -247,5 +247,15 @@ namespace Buttplug.Server
             aMgr.DeviceAdded += DeviceAddedHandler;
             aMgr.ScanningFinished += ScanningFinishedHandler;
         }
+
+        public bool SetVersoseDeviceLogging(bool verbose)
+        {
+            foreach (var manager in _managers)
+            {
+                manager.VerboseDeviceLogging = verbose;
+            }
+
+            return verbose;
+        }
     }
 }

--- a/Buttplug.Server/DeviceSubtypeManager.cs
+++ b/Buttplug.Server/DeviceSubtypeManager.cs
@@ -11,6 +11,14 @@ namespace Buttplug.Server
         [NotNull]
         protected readonly IButtplugLogManager LogManager;
 
+        private bool _verboseDeviceLogging = false;
+
+        public bool VerboseDeviceLogging
+        {
+            get => _verboseDeviceLogging;
+            set => _verboseDeviceLogging = value;
+        }
+
         public event EventHandler<DeviceAddedEventArgs> DeviceAdded;
 
         public event EventHandler<EventArgs> ScanningFinished;

--- a/Buttplug.Server/IDeviceSubtypeManager.cs
+++ b/Buttplug.Server/IDeviceSubtypeManager.cs
@@ -5,6 +5,8 @@ namespace Buttplug.Server
 {
     public interface IDeviceSubtypeManager
     {
+        bool VerboseDeviceLogging { get; set; }
+
         [CanBeNull]
         event EventHandler<DeviceAddedEventArgs> DeviceAdded;
 


### PR DESCRIPTION
The GUI to enable the extra trace logging is in the hidden developer tab.
For BLE, this outputs a list of service UUIDs and handles, and the UUIDs
and handles for the Characteristics for the service.

Fixes #258