### PR TITLE
WIP: IPC transport

### DIFF
--- a/Buttplug.Apps.ExampleClientGUI/ExampleClientPanel.xaml
+++ b/Buttplug.Apps.ExampleClientGUI/ExampleClientPanel.xaml
@@ -14,11 +14,18 @@
 			<RowDefinition Height="Auto"/>
 			<RowDefinition Height="*"/>
 		</Grid.RowDefinitions>
-		<Label Content="Address:"  Grid.Row="0" HorizontalAlignment="Left" Margin="0,0,0,0" VerticalAlignment="Center"/>
-		<TextBox Name="AdressTextBox"  Grid.Row="0" HorizontalAlignment="Left" Height="23" Margin="80,0,0,0" TextWrapping="Wrap" Text="ws://localhost:12345" VerticalAlignment="Center" Width="120"/>
-		<Button Name="ConnToggleButton"  Grid.Row="0" Content="Connect" HorizontalAlignment="Right" Margin="0,0,0,0" VerticalAlignment="Center" Width="75" Click="ConnToggleButton_Click"/>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="Auto"/>
+			<ColumnDefinition Width="Auto"/>
+			<ColumnDefinition Width="*"/>
+			<ColumnDefinition Width="Auto"/>
+		</Grid.ColumnDefinitions>
+		<Label Content="Address:" Grid.Row="0"  Grid.Column="0" VerticalAlignment="Center"/>
+		<TextBox Name="AdressTextBox"  Grid.Row="0" Grid.Column="1" Text="wss://localhost:12345" VerticalAlignment="Center" Width="120"/>
+		<CheckBox Name="UseIPC" Grid.Row="0" Grid.Column="2" Content="Use IPC" VerticalAlignment="Center" Checked="UseIPC_Checked" Unchecked="UseIPC_Unchecked"/>
+		<Button Name="ConnToggleButton"  Grid.Row="0" Grid.Column="3" Content="Connect" HorizontalAlignment="Right" Margin="0,0,0,0" VerticalAlignment="Center" Width="75" Click="ConnToggleButton_Click"/>
 
-		<GroupBox Grid.Row="1" Header="Linear (Fleshlight Launch)">
+		<GroupBox Grid.Row="1" Grid.ColumnSpan="4" Header="Linear (Fleshlight Launch)">
 			<Grid>
 				<Grid.RowDefinitions>
 					<RowDefinition Height="Auto"/>
@@ -37,7 +44,7 @@
 			</Grid>
 		</GroupBox>
 
-		<GroupBox Grid.Row="2" Header="Linear (generic)">
+		<GroupBox Grid.Row="2" Grid.ColumnSpan="4" Header="Linear (generic)">
 			<Grid>
 				<Grid.RowDefinitions>
 					<RowDefinition Height="Auto"/>
@@ -56,7 +63,7 @@
 			</Grid>
 		</GroupBox>
 
-		<GroupBox Grid.Row="3" Header="Vibrate">
+		<GroupBox Grid.Row="3" Grid.ColumnSpan="4" Header="Vibrate">
 			<Grid>
 				<Grid.RowDefinitions>
 					<RowDefinition Height="Auto"/>
@@ -71,8 +78,8 @@
 				<Button Name="SendVibrate" Content="Send" Grid.Row="0" Grid.Column="2" Click="SendVibrate_Click"/>
 			</Grid>
 		</GroupBox>
-		
-		<GroupBox Grid.Row="4" Header="Rotate">
+
+		<GroupBox Grid.Row="4" Grid.ColumnSpan="4" Header="Rotate">
 			<Grid>
 				<Grid.RowDefinitions>
 					<RowDefinition Height="Auto"/>

--- a/Buttplug.Apps.WebsocketServerGUI/Buttplug.Apps.WebsocketServerGUI.csproj
+++ b/Buttplug.Apps.WebsocketServerGUI/Buttplug.Apps.WebsocketServerGUI.csproj
@@ -133,6 +133,10 @@
       <Project>{0e0d1e27-9efd-4a07-b6aa-bb556205c002}</Project>
       <Name>Buttplug.Components.Controls</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Buttplug.Components.IPCServer\Buttplug.Components.IPCServer.csproj">
+      <Project>{a235b077-d870-49f0-9d6d-2a5d26726efc}</Project>
+      <Name>Buttplug.Components.IPCServer</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Buttplug.Core\Buttplug.Core.csproj">
       <Project>{fc4af8fe-8c21-4e07-8d24-7fb7791149d0}</Project>
       <Name>Buttplug.Core</Name>

--- a/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
+++ b/Buttplug.Apps.WebsocketServerGUI/WebsocketServerControl.xaml
@@ -14,6 +14,7 @@
         <Label Content="Port:"  Grid.Row="0" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top"/>
         <TextBox Name="PortTextBox"  Grid.Row="0" HorizontalAlignment="Left" Height="23" Margin="60,14,0,0" TextWrapping="Wrap" Text="12345" VerticalAlignment="Top" Width="120" LostFocus="PortTextBox_LostFocus"/>
         <CheckBox Name="SecureCheckBox"  Grid.Row="0" Content="SSL/TLS" HorizontalAlignment="Right" Margin="0,17,10,0" VerticalAlignment="Top" Unchecked="SecureCheckBox_Unchecked" Checked="SecureCheckBox_Checked"/>
+	    <CheckBox Name="IPCCheckBox"  Grid.Row="0" Content="IPC" HorizontalAlignment="Right" Margin="0,17,200,0" VerticalAlignment="Top" Unchecked="IPCCheckBox_Unchecked" Checked="IPCCheckBox_Checked"/>
         <CheckBox Name="LoopbackCheckBox"  Grid.Row="0" Content="Localhost Only" HorizontalAlignment="Right" Margin="0,17,90,0" VerticalAlignment="Top" Unchecked="LoopbackCheckBox_Unchecked" Checked="LoopbackCheckBox_Checked"/>
         <Button Name="ConnToggleButton"  Grid.Row="1" Content="Start" HorizontalAlignment="Right" Margin="0,0,10,0" VerticalAlignment="Top" Width="75" Click="ConnToggleButton_Click"/>
         

--- a/Buttplug.Client/ButtplugAbsractClient.cs
+++ b/Buttplug.Client/ButtplugAbsractClient.cs
@@ -1,0 +1,376 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Buttplug.Core;
+using Buttplug.Core.Messages;
+using JetBrains.Annotations;
+using WebSocket4Net;
+
+namespace Buttplug.Client
+{
+    public abstract class ButtplugAbsractClient : IButtplugClient
+    {
+        /// <summary>
+        /// Used for converting messages between JSON and Objects.
+        /// </summary>
+        [NotNull]
+        protected readonly ButtplugJsonMessageParser _parser;
+
+        /// <summary>
+        /// Global logger instance for the client.
+        /// </summary>
+        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
+        [NotNull]
+        protected readonly IButtplugLog _bpLogger;
+
+        /// <summary>
+        /// Name of the client, used for server UI/permissions.
+        /// </summary>
+        [NotNull]
+        protected readonly string _clientName;
+
+        /// <summary>
+        /// Used for canceling out of websocket wait loops.
+        /// </summary>
+        [NotNull]
+        protected CancellationTokenSource _tokenSource;
+
+        /// <summary>
+        /// Used for dispatching events to the owning application context.
+        /// </summary>
+        [NotNull]
+        protected readonly SynchronizationContext _owningDispatcher;
+
+        /// <summary>
+        /// Stores messages waiting for reply from the server.
+        /// </summary>
+        [NotNull]
+        protected readonly ConcurrentDictionary<uint, TaskCompletionSource<ButtplugMessage>> _waitingMsgs =
+            new ConcurrentDictionary<uint, TaskCompletionSource<ButtplugMessage>>();
+
+        /// <summary>
+        /// Stores information about devices currently connected to the server.
+        /// </summary>
+        [NotNull]
+        protected readonly ConcurrentDictionary<uint, ButtplugClientDevice> _devices =
+            new ConcurrentDictionary<uint, ButtplugClientDevice>();
+
+        /// <summary>
+        /// Ping timer.
+        /// </summary>
+        /// <remarks>
+        /// Sends a ping message to the server whenever the timer triggers. Usually runs at
+        /// (requested ping interval / 2).
+        /// </remarks>
+        [CanBeNull] protected Timer _pingTimer;
+
+        /// <summary>
+        /// Event fired on Buttplug device added, either after connect or while scanning for devices.
+        /// </summary>
+        [CanBeNull]
+        public virtual event EventHandler<DeviceEventArgs> DeviceAdded;
+
+        /// <summary>
+        /// Event fired on Buttplug device removed. Can fire at any time after device connection.
+        /// </summary>
+        [CanBeNull]
+        public virtual event EventHandler<DeviceEventArgs> DeviceRemoved;
+
+        /// <summary>
+        /// Event fired when the server has finished scanning for devices.
+        /// </summary>
+        [CanBeNull]
+        public virtual event EventHandler<ScanningFinishedEventArgs> ScanningFinished;
+
+        /// <summary>
+        /// Event fired when an error has been encountered. This may be internal client exceptions or
+        /// Error messages from the server.
+        /// </summary>
+        [CanBeNull]
+        public virtual event EventHandler<ErrorEventArgs> ErrorReceived;
+
+        /// <summary>
+        /// Event fired when the client receives a Log message. Should only fire if the client has
+        /// requested that log messages be sent.
+        /// </summary>
+        [CanBeNull]
+        public virtual event EventHandler<LogEventArgs> Log;
+
+        /// <summary>
+        /// Gets the next available message ID. In most cases, setting the message ID is done automatically.
+        /// </summary>
+        public uint NextMsgId => Convert.ToUInt32(Interlocked.Increment(ref _counter));
+
+        /// <summary>
+        /// Stores the last used current message ID.
+        /// </summary>
+        protected int _counter;
+
+        /// <summary>
+        /// Gets the connected Buttplug devices.
+        /// </summary>
+        public ButtplugClientDevice[] Devices => _devices.Values.ToArray();
+
+        /// <summary>
+        /// Status of the client connection.
+        /// </summary>
+        /// <returns>True if client is currently connected.</returns>
+        public abstract bool IsConnected { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IButtplugClient"/> class.
+        /// </summary>
+        /// <param name="aClientName">The name of the client (used by the server for UI and permissions).</param>
+        protected ButtplugAbsractClient(string aClientName)
+        {
+            _clientName = aClientName;
+            IButtplugLogManager bpLogManager = new ButtplugLogManager();
+            _bpLogger = bpLogManager.GetLogger(GetType());
+            _parser = new ButtplugJsonMessageParser(bpLogManager);
+            _bpLogger.Info("Finished setting up ButtplugClient");
+            _owningDispatcher = SynchronizationContext.Current ?? new SynchronizationContext();
+            _tokenSource = new CancellationTokenSource();
+            _counter = 0;
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="ButtplugAbstractClient"/> class, closing the transport
+        /// connection if it is still open.
+        /// </summary>
+        ~ButtplugAbsractClient()
+        {
+            Disconnect().Wait();
+        }
+
+        /// <summary>
+        /// Creates the connection to the Buttplug Server and performs the protocol handshake.
+        /// </summary>
+        /// <remarks>
+        /// Once the transport connection is open, the RequestServerInfo message is sent; the
+        /// response is used to set up the ping timer loop. The RequestDeviceList message is also
+        /// sent, so that any devices the server is already connected to are made known to the client.
+        ///
+        /// <b>Important:</b> Ensure that <see cref="DeviceAdded"/>, <see cref="DeviceRemoved"/> and
+        /// <see cref="ErrorReceived"/> handlers are set before Connect is called.
+        /// </remarks>
+        /// <param name="aURL">
+        /// The URI for the Buttplug Server over the specified transport.
+        /// </param>
+        /// <param name="aIgnoreSSLErrors">
+        /// When using SSL (wss://), prevents bad certificates from causing connection failures
+        /// </param>
+        /// <returns>Nothing (Task used for async/await)</returns>
+        [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Embedded acronyms")]
+        public abstract Task Connect(Uri aURL, bool aIgnoreSSLErrors = false);
+
+        /// <summary>
+        /// Closes the transport connection.
+        /// </summary>
+        /// <returns>Nothing (Task used for async/await)</returns>
+        public abstract Task Disconnect();
+
+        /// <summary>
+        /// Buttplug Message Received handler. Either tries to match incoming messages as
+        /// replies to messages we've sent, or fires an event related to an incoming event, like
+        /// device additions/removals, log messages, etc.
+        /// </summary>
+        /// <param name="aMsgs">An array of deserialized Buttplug messages.</param>
+        protected void MessageReceivedHandler(ButtplugMessage[] aMsgs)
+        {
+            foreach (var msg in aMsgs)
+            {
+                if (msg.Id > 0 && _waitingMsgs.TryRemove(msg.Id, out TaskCompletionSource<ButtplugMessage> queued))
+                {
+                    queued.TrySetResult(msg);
+                    continue;
+                }
+
+                switch (msg)
+                {
+                    case Log l:
+                        _owningDispatcher.Send(_ =>
+                        {
+                            Log?.Invoke(this, new LogEventArgs(l));
+                        }, null);
+                        break;
+
+                    case DeviceAdded d:
+                        var dev = new ButtplugClientDevice(d);
+                        _devices.AddOrUpdate(d.DeviceIndex, dev, (idx, old) => dev);
+                        _owningDispatcher.Send(_ =>
+                        {
+                            DeviceAdded?.Invoke(this, new DeviceEventArgs(dev, DeviceEventArgs.DeviceAction.ADDED));
+                        }, null);
+                        break;
+
+                    case DeviceRemoved d:
+                        if (_devices.TryRemove(d.DeviceIndex, out ButtplugClientDevice oldDev))
+                        {
+                            _owningDispatcher.Send(_ =>
+                            {
+                                DeviceRemoved?.Invoke(this, new DeviceEventArgs(oldDev, DeviceEventArgs.DeviceAction.REMOVED));
+                            }, null);
+                        }
+
+                        break;
+
+                    case ScanningFinished sf:
+                        _owningDispatcher.Send(_ =>
+                        {
+                            ScanningFinished?.Invoke(this, new ScanningFinishedEventArgs(sf));
+                        }, null);
+                        break;
+
+                    case Error e:
+                        _owningDispatcher.Send(_ =>
+                        {
+                            ErrorReceived?.Invoke(this, new ErrorEventArgs(e));
+                        }, null);
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Manages the ping timer, sending pings at the rate faster than requested by the server. If
+        /// the ping timer handler does not run, it means the event loop is blocked, and the server
+        /// will stop all devices and disconnect.
+        /// </summary>
+        /// <param name="aState">State of the Timer.</param>
+        protected async void OnPingTimer(object state)
+        {
+            try
+            {
+                var msg = await SendMessage(new Ping());
+                if (msg is Error)
+                {
+                    _owningDispatcher.Send(_ =>
+                    {
+                        ErrorReceived?.Invoke(this, new ErrorEventArgs(msg as Error));
+                    }, null);
+                    throw new Exception((msg as Error).ErrorMessage);
+                }
+            }
+            catch
+            {
+                await Disconnect();
+            }
+        }
+
+        /// <summary>
+        /// Instructs the server to start scanning for devices. New devices will be raised as <see
+        /// cref="DeviceAdded"/> events. When scanning completes, an <see cref="ScanningFinished"/>
+        /// event will be triggered.
+        /// </summary>
+        /// <returns>
+        /// True if successful. If there are errors while the server is starting scanning, a <see
+        /// cref="ErrorReceived"/> event will be triggered.
+        /// </returns>
+        public async Task<bool> StartScanning()
+        {
+            return await SendMessageExpectOk(new StartScanning());
+        }
+
+        /// <summary>
+        /// Instructs the server to stop scanning for devices. If scanning was in progress, a <see
+        /// cref="ScanningFinished"/> event will be sent when the server has stopped scanning.
+        /// </summary>
+        /// <returns>
+        /// True if the server successful recieved the command. If there are errors while the server
+        /// is stopping scanning, a <see cref="ErrorReceived"/> event will be triggered.
+        /// </returns>
+        public async Task<bool> StopScanning()
+        {
+            return await SendMessageExpectOk(new StopScanning());
+        }
+
+        /// <summary>
+        /// Instructs the server to either forward or stop log entries to the client. Log entries
+        /// will be raised as <see cref="Log"/> events.
+        /// </summary>
+        /// <param name="aLogLevel">The maximum log level to send.</param>
+        /// <returns>
+        /// True if successful. If there are errors while the server is stopping scanning, a <see
+        /// cref="ErrorReceived"/> event will be triggered.
+        /// </returns>
+        public async Task<bool> RequestLog(string aLogLevel)
+        {
+            return await SendMessageExpectOk(new RequestLog(aLogLevel));
+        }
+
+        /// <summary>
+        /// Sends a DeviceMessage (e.g. <see cref="VibrateCmd"/> or <see cref="LinearCmd"/>). Handles
+        /// constructing some parts of the message for the user.
+        /// </summary>
+        /// <param name="aDevice">The device to be controlled by the message.</param>
+        /// <param name="aDeviceMsg">The device message (Id and DeviceIndex will be overriden).</param>
+        /// <returns>
+        /// <see cref="Ok"/> message on success, <see cref="Error"/> message with error info otherwise.
+        /// </returns>
+        public async Task<ButtplugMessage> SendDeviceMessage(ButtplugClientDevice aDevice, ButtplugDeviceMessage aDeviceMsg)
+        {
+            if (!_devices.TryGetValue(aDevice.Index, out ButtplugClientDevice dev))
+            {
+                return new Error("Device not available.", Error.ErrorClass.ERROR_DEVICE, ButtplugConsts.SystemMsgId);
+            }
+
+            if (!dev.AllowedMessages.ContainsKey(aDeviceMsg.GetType().Name))
+            {
+                return new Error("Device does not accept message type: " + aDeviceMsg.GetType().Name, Error.ErrorClass.ERROR_DEVICE, ButtplugConsts.SystemMsgId);
+            }
+
+            aDeviceMsg.DeviceIndex = aDevice.Index;
+            return await SendMessage(aDeviceMsg);
+        }
+
+        /// <summary>
+        /// Sends a message, expecting a response of message type <see cref="Ok"/>.
+        /// </summary>
+        /// <param name="aMsg">Message to send.</param>
+        /// <returns>True if successful.</returns>
+        protected async Task<bool> SendMessageExpectOk(ButtplugMessage aMsg)
+        {
+            return await SendMessage(aMsg) is Ok;
+        }
+
+        /// <summary>
+        /// Sends a message to the server, and handles asynchronously waiting for the reply from the server.
+        /// </summary>
+        /// <param name="aMsg">Message to send.</param>
+        /// <returns>The response, which will derive from <see cref="ButtplugMessage"/>.</returns>
+        protected abstract Task<ButtplugMessage> SendMessage(ButtplugMessage aMsg);
+
+        /// <summary>
+        /// Converts a single <see cref="ButtplugMessage"/> into a JSON string.
+        /// </summary>
+        /// <param name="aMsg">Message to convert.</param>
+        /// <returns>The JSON string representation of the message.</returns>
+        protected string Serialize(ButtplugMessage aMsg)
+        {
+            return _parser.Serialize(aMsg, ButtplugMessage.CurrentSchemaVersion);
+        }
+
+        /// <summary>
+        /// Converts an array of <see cref="ButtplugMessage"/> into a JSON string.
+        /// </summary>
+        /// <param name="aMsgs">An array of messages to convert.</param>
+        /// <returns>The JSON string representation of the messages.</returns>
+        protected string Serialize(ButtplugMessage[] aMsgs)
+        {
+            return _parser.Serialize(aMsgs, ButtplugMessage.CurrentSchemaVersion);
+        }
+
+        /// <summary>
+        /// Converts a JSON string into an array of <see cref="ButtplugMessage"/>.
+        /// </summary>
+        /// <param name="aMsg">A JSON string representing one or more messages.</param>
+        /// <returns>An array of <see cref="ButtplugMessage"/>.</returns>
+        protected ButtplugMessage[] Deserialize(string aMsg)
+        {
+            return _parser.Deserialize(aMsg);
+        }
+    }
+}

--- a/Buttplug.Client/ButtplugIPCClient.cs
+++ b/Buttplug.Client/ButtplugIPCClient.cs
@@ -1,0 +1,324 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.IO.Pipes;
+using System.Linq;
+using System.Security.Principal;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Buttplug.Core;
+using Buttplug.Core.Messages;
+using JetBrains.Annotations;
+using WebSocket4Net;
+using static Buttplug.Client.DeviceEventArgs;
+
+namespace Buttplug.Client
+{
+    /// <summary>
+    /// This is the Buttplug C# WebSocket Client implementation.
+    /// It's intended to abstract away the process of communicating with
+    /// a Buttplug Server over Named Pipes, so you don't have to worry
+    /// about the lower level protocol.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public class ButtplugIPCClient : ButtplugAbsractClient
+    {
+        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
+
+        [NotNull] private readonly object _sendLock = new object();
+
+        private NamedPipeClientStream _pipeClient;
+
+        private Task _readThread;
+
+        private ConcurrentQueue<ButtplugMessage> _msgQueue = new ConcurrentQueue<ButtplugMessage>();
+
+        /// <summary>
+        /// Event fired on Buttplug device added
+        /// Should fire only immediately after connect or whilst scanning for devices
+        /// </summary>
+        [CanBeNull]
+        public override event EventHandler<DeviceEventArgs> DeviceAdded;
+
+        /// <summary>
+        /// Event fired on Buttplug device removed
+        /// Can fire are any time
+        /// </summary>
+        [CanBeNull]
+        public override event EventHandler<DeviceEventArgs> DeviceRemoved;
+
+        /// <summary>
+        /// Event fired when the server has stopped scanning for devices
+        /// </summary>
+        [CanBeNull]
+        public override event EventHandler<ScanningFinishedEventArgs> ScanningFinished;
+
+        /// <summary>
+        /// Event fired when an error has been encountered
+        /// This may be internal client exceptions or Error messages from the server
+        /// </summary>
+        [CanBeNull]
+        public override event EventHandler<ErrorEventArgs> ErrorReceived;
+
+        /// <summary>
+        /// Event fired when the client recieves a Log message
+        /// Should only fire if the client requests logs
+        /// </summary>
+        [CanBeNull]
+        public override event EventHandler<LogEventArgs> Log;
+
+        /// <summary>
+        /// Used for error handling during the connection process.
+        /// </summary>
+        private bool _connecting;
+
+        /// <summary>
+        /// Status of the client connection.
+        /// </summary>
+        /// <returns>True if client is currently connected.</returns>
+        public override bool IsConnected => _pipeClient?.IsConnected ?? false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ButtplugIPCClient"/> class.
+        /// </summary>
+        /// <param name="aClientName">The name of the client to present to the server</param>
+        public ButtplugIPCClient(string aClientName)
+            : base(aClientName)
+        {
+        }
+
+        /// <summary>
+        /// Creates the connection to the Buttplug Server and performs the protocol hanshake.
+        /// Once the WebSocket connetion is open, the RequestServerInfo message is sent;
+        /// the response is used to set up the ping timer loop. The RequestDeviceList
+        /// message is also sent here so that any devices the server is already connected to
+        /// are made known to the client.
+        ///
+        /// <b>Important:</b> Ensure that <see cref="DeviceAdded"/>, <see cref="DeviceRemoved"/>
+        /// and <see cref="ErrorReceived"/> handlers are set before Connect is called.
+        /// </summary>
+        /// <param name="aURL">The URL for the Buttplug WebSocket Server. This will likely be in the form wss://localhost:12345 (wss:// is to ws:// as https:// is to http://)</param>
+        /// <param name="aIgnoreSSLErrors">When using SSL (wss://), this option prevents bad certificates from causing connection failures</param>
+        /// <returns>An untyped Task; the await/async equivelent of void</returns>
+        [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Embedded acronyms")]
+        public override async Task Connect(Uri aURL, bool aIgnoreSSLErrors = false)
+        {
+            if (IsConnected)
+            {
+                throw new InvalidOperationException("Already connected!");
+            }
+
+            _pipeClient = new NamedPipeClientStream(".",
+                aURL.Host,
+                PipeDirection.InOut, PipeOptions.Asynchronous,
+                TokenImpersonationLevel.Impersonation);
+            _waitingMsgs.Clear();
+            _devices.Clear();
+            _counter = 1;
+
+            _connecting = true;
+            _pipeClient.Connect(2000);
+            _connecting = false;
+
+            _tokenSource = new CancellationTokenSource();
+            _readThread = new Task(() => { pipeReader(_tokenSource.Token); }, _tokenSource.Token,
+                TaskCreationOptions.LongRunning);
+            _readThread.Start();
+
+            var res = await SendMessage(new RequestServerInfo(_clientName));
+            switch (res)
+            {
+                case ServerInfo si:
+                    if (si.MaxPingTime > 0)
+                    {
+                        _pingTimer = new Timer(OnPingTimer, null, 0,
+                            Convert.ToInt32(Math.Round(((double)si.MaxPingTime) / 2, 0)));
+                    }
+
+                    if (si.MessageVersion < ButtplugMessage.CurrentSchemaVersion)
+                    {
+                        throw new Exception("Buttplug Server's schema version (" + si.MessageVersion +
+                                            ") is less than the client's (" + ButtplugMessage.CurrentSchemaVersion +
+                                            "). A newer server is required.");
+                    }
+
+                    // Get full device list and populate internal list
+                    var resp = await SendMessage(new RequestDeviceList());
+                    if ((resp as DeviceList)?.Devices == null)
+                    {
+                        if (resp is Error)
+                        {
+                            _owningDispatcher.Send(
+                                _ => { ErrorReceived?.Invoke(this, new ErrorEventArgs(resp as Error)); }, null);
+                        }
+
+                        return;
+                    }
+
+                    foreach (var d in (resp as DeviceList).Devices)
+                    {
+                        if (_devices.ContainsKey(d.DeviceIndex))
+                        {
+                            continue;
+                        }
+
+                        var device = new ButtplugClientDevice(d);
+                        if (_devices.TryAdd(d.DeviceIndex, device))
+                        {
+                            _owningDispatcher.Send(
+                                _ => { DeviceAdded?.Invoke(this, new DeviceEventArgs(device, DeviceAction.ADDED)); },
+                                null);
+                        }
+                    }
+
+                    break;
+
+                case Error e:
+                    throw new Exception(e.ErrorMessage);
+
+                default:
+                    throw new Exception("Unexpected message returned: " + res.GetType());
+            }
+        }
+
+        /// <summary>
+        /// Closes the WebSocket Connection.
+        /// </summary>
+        /// <returns>An untyped Task; the await/async equivelent of void</returns>
+        public override async Task Disconnect()
+        {
+            if (_pingTimer != null)
+            {
+                _pingTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                _pingTimer = null;
+            }
+
+            try
+            {
+                while (IsConnected)
+                {
+                    _pipeClient.Close();
+                }
+            }
+            catch
+            {
+                // noop - something when wrong closing the socket, but we're
+                // about to dispose of it anyway.
+            }
+
+            try
+            {
+                _tokenSource.Cancel();
+            }
+            catch
+            {
+                // noop - something when wrong closing the socket, but we're
+                // about to dispose of it anyway.
+            }
+
+            _pipeClient = null;
+
+            var max = 3;
+            while (max-- > 0 && _waitingMsgs.Count != 0)
+            {
+                foreach (var msgId in _waitingMsgs.Keys)
+                {
+                    if (_waitingMsgs.TryRemove(msgId, out TaskCompletionSource<ButtplugMessage> promise))
+                    {
+                        promise.SetResult(new Error("Connection closed!", Error.ErrorClass.ERROR_UNKNOWN,
+                            ButtplugConsts.SystemMsgId));
+                    }
+                }
+            }
+
+            _counter = 1;
+        }
+
+        /// <summary>
+        /// Sends a message and returns the resulting message
+        /// </summary>
+        /// <param name="aMsg">Message to send.</param>
+        /// <returns>The response <see cref="ButtplugMessage"/></returns>
+        protected override async Task<ButtplugMessage> SendMessage(ButtplugMessage aMsg)
+        {
+            // The client always increments the IDs on outgoing messages
+            aMsg.Id = NextMsgId;
+
+            var promise = new TaskCompletionSource<ButtplugMessage>();
+            _waitingMsgs.TryAdd(aMsg.Id, promise);
+
+            var output = Encoding.ASCII.GetBytes(Serialize(aMsg));
+
+            try
+            {
+                lock (_sendLock)
+                {
+                    if (IsConnected)
+                    {
+                        _pipeClient.Write(output, 0, output.Length);
+                    }
+                    else
+                    {
+                        return new Error("Bad WS state!", Error.ErrorClass.ERROR_UNKNOWN, ButtplugConsts.SystemMsgId);
+                    }
+                }
+
+                return await promise.Task;
+            }
+            catch (Exception e)
+            {
+                // Noop - WS probably closed on us during read
+                return new Error(e.Message, Error.ErrorClass.ERROR_UNKNOWN, ButtplugConsts.SystemMsgId);
+            }
+        }
+
+        private void pipeReader(CancellationToken aCancellationToken)
+        {
+            while (!aCancellationToken.IsCancellationRequested && _pipeClient != null && _pipeClient.IsConnected)
+            {
+                var buffer = new byte[4096];
+                string msg = string.Empty;
+                var len = -1;
+                while (len < 0 || (len == buffer.Length && buffer[4095] != '\0'))
+                {
+                    try
+                    {
+                        var waiter = _pipeClient.ReadAsync(buffer, 0, buffer.Length, aCancellationToken);
+                        while (!waiter.GetAwaiter().IsCompleted)
+                        {
+                            if (!_pipeClient.IsConnected)
+                            {
+                                return;
+                            }
+
+                            Thread.Sleep(10);
+                        }
+
+                        len = waiter.GetAwaiter().GetResult();
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+
+                    if (len > 0)
+                    {
+                        msg += Encoding.ASCII.GetString(buffer, 0, len);
+                    }
+                }
+
+                Console.Out.WriteLine(msg);
+                var parsed = _parser.Deserialize(msg);
+
+                MessageReceivedHandler(parsed);
+            }
+
+            if (IsConnected)
+            {
+                Disconnect().Wait();
+            }
+        }
+    }
+}

--- a/Buttplug.Client/ButtplugWSClient.cs
+++ b/Buttplug.Client/ButtplugWSClient.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
@@ -16,20 +14,39 @@ namespace Buttplug.Client
     /// Handles communicating with a Buttplug Server over WebSockets.
     /// </summary>
     // ReSharper disable once InconsistentNaming
-    public class ButtplugWSClient
+    public class ButtplugWSClient : ButtplugAbsractClient
     {
         /// <summary>
-        /// Used for converting messages between JSON and Objects.
+        /// Event fired on Buttplug device added, either after connect or while scanning for devices.
         /// </summary>
-        [NotNull]
-        private readonly ButtplugJsonMessageParser _parser;
+        [CanBeNull]
+        public override event EventHandler<DeviceEventArgs> DeviceAdded;
 
         /// <summary>
-        /// Global logger instance for the client.
+        /// Event fired on Buttplug device removed. Can fire at any time after device connection.
         /// </summary>
-        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
-        [NotNull]
-        private readonly IButtplugLog _bpLogger;
+        [CanBeNull]
+        public override event EventHandler<DeviceEventArgs> DeviceRemoved;
+
+        /// <summary>
+        /// Event fired when the server has finished scanning for devices.
+        /// </summary>
+        [CanBeNull]
+        public override event EventHandler<ScanningFinishedEventArgs> ScanningFinished;
+
+        /// <summary>
+        /// Event fired when an error has been encountered. This may be internal client exceptions or
+        /// Error messages from the server.
+        /// </summary>
+        [CanBeNull]
+        public override event EventHandler<ErrorEventArgs> ErrorReceived;
+
+        /// <summary>
+        /// Event fired when the client receives a Log message. Should only fire if the client has
+        /// requested that log messages be sent.
+        /// </summary>
+        [CanBeNull]
+        public override event EventHandler<LogEventArgs> Log;
 
         /// <summary>
         /// Guards re-entrancy of websocket message sending function.
@@ -38,86 +55,10 @@ namespace Buttplug.Client
         private readonly object _sendLock = new object();
 
         /// <summary>
-        /// Name of the client, used for server UI/permissions.
-        /// </summary>
-        [NotNull]
-        private readonly string _clientName;
-
-        /// <summary>
-        /// Used for cancelling out of websocket wait loops.
-        /// </summary>
-        [NotNull]
-        private readonly CancellationTokenSource _tokenSource;
-
-        /// <summary>
-        /// Used for dispatching events to the owning application context.
-        /// </summary>
-        [NotNull]
-        private readonly SynchronizationContext _owningDispatcher;
-
-        /// <summary>
-        /// Stores messages waiting for reply from the server.
-        /// </summary>
-        [NotNull]
-        private readonly ConcurrentDictionary<uint, TaskCompletionSource<ButtplugMessage>> _waitingMsgs =
-            new ConcurrentDictionary<uint, TaskCompletionSource<ButtplugMessage>>();
-
-        /// <summary>
-        /// Stores information about devices currently connected to the server.
-        /// </summary>
-        [NotNull]
-        private readonly ConcurrentDictionary<uint, ButtplugClientDevice> _devices =
-            new ConcurrentDictionary<uint, ButtplugClientDevice>();
-
-        /// <summary>
         /// Websocket access object.
         /// </summary>
         [CanBeNull]
         private WebSocket _ws;
-
-        /// <summary>
-        /// Ping timer.
-        /// </summary>
-        /// <remarks>
-        /// Sends a ping message to the server whenever the timer triggers. Usually runs at
-        /// (requested ping interval / 2).
-        /// </remarks>
-        [CanBeNull]
-        private Timer _pingTimer;
-
-        private int _counter;
-
-        /// <summary>
-        /// Event fired on Buttplug device added, either after connect or while scanning for devices.
-        /// </summary>
-        [CanBeNull]
-        public event EventHandler<DeviceEventArgs> DeviceAdded;
-
-        /// <summary>
-        /// Event fired on Buttplug device removed. Can fire at any time after device connection.
-        /// </summary>
-        [CanBeNull]
-        public event EventHandler<DeviceEventArgs> DeviceRemoved;
-
-        /// <summary>
-        /// Event fired when the server has finished scanning for devices.
-        /// </summary>
-        [CanBeNull]
-        public event EventHandler<ScanningFinishedEventArgs> ScanningFinished;
-
-        /// <summary>
-        /// Event fired when an error has been encountered. This may be internal client exceptions or
-        /// Error messages from the server.
-        /// </summary>
-        [CanBeNull]
-        public event EventHandler<ErrorEventArgs> ErrorReceived;
-
-        /// <summary>
-        /// Event fired when the client receives a Log message. Should only fire if the client has
-        /// requested that log messages be sent.
-        /// </summary>
-        [CanBeNull]
-        public event EventHandler<LogEventArgs> Log;
 
         /// <summary>
         /// Signifies the end of the connection process.
@@ -135,20 +76,10 @@ namespace Buttplug.Client
         private bool _connecting;
 
         /// <summary>
-        /// Gets the next available message ID. In most cases, setting the message ID is done automatically.
-        /// </summary>
-        public uint NextMsgId => Convert.ToUInt32(Interlocked.Increment(ref _counter));
-
-        /// <summary>
-        /// Gets the connected Buttplug devices.
-        /// </summary>
-        public ButtplugClientDevice[] Devices => _devices.Values.ToArray();
-
-        /// <summary>
         /// Status of the client connection.
         /// </summary>
         /// <returns>True if client is currently connected.</returns>
-        public bool IsConnected => _ws != null &&
+        public override bool IsConnected => _ws != null &&
                                    (_ws.State == WebSocketState.Connecting ||
                                     _ws.State == WebSocketState.Open);
 
@@ -157,24 +88,8 @@ namespace Buttplug.Client
         /// </summary>
         /// <param name="aClientName">The name of the client (used by the server for UI and permissions).</param>
         public ButtplugWSClient(string aClientName)
+            : base(aClientName)
         {
-            _clientName = aClientName;
-            IButtplugLogManager bpLogManager = new ButtplugLogManager();
-            _bpLogger = bpLogManager.GetLogger(GetType());
-            _parser = new ButtplugJsonMessageParser(bpLogManager);
-            _bpLogger.Info("Finished setting up ButtplugClient");
-            _owningDispatcher = SynchronizationContext.Current ?? new SynchronizationContext();
-            _tokenSource = new CancellationTokenSource();
-            _counter = 0;
-        }
-
-        /// <summary>
-        /// Finalizes an instance of the <see cref="ButtplugWSClient"/> class, closing the websocket
-        /// connection if it is still open.
-        /// </summary>
-        ~ButtplugWSClient()
-        {
-            Disconnect().Wait();
         }
 
         /// <summary>
@@ -197,7 +112,7 @@ namespace Buttplug.Client
         /// </param>
         /// <returns>Nothing (Task used for async/await)</returns>
         [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Embedded acronyms")]
-        public async Task Connect(Uri aURL, bool aIgnoreSSLErrors = false)
+        public override async Task Connect(Uri aURL, bool aIgnoreSSLErrors = false)
         {
             if (_ws != null && (_ws.State == WebSocketState.Connecting || _ws.State == WebSocketState.Open))
             {
@@ -345,7 +260,7 @@ namespace Buttplug.Client
         /// Closes the WebSocket Connection.
         /// </summary>
         /// <returns>Nothing (Task used for async/await)</returns>
-        public async Task Disconnect()
+        public override async Task Disconnect()
         {
             if (_pingTimer != null)
             {
@@ -406,164 +321,7 @@ namespace Buttplug.Client
         /// <param name="aArgs">Event parameters, including the data received.</param>
         private void MessageReceivedHandler(object aSender, WebSocket4Net.MessageReceivedEventArgs aArgs)
         {
-            var msgs = Deserialize(aArgs.Message);
-            foreach (var msg in msgs)
-            {
-                if (msg.Id > 0 && _waitingMsgs.TryRemove(msg.Id, out TaskCompletionSource<ButtplugMessage> queued))
-                {
-                    queued.TrySetResult(msg);
-                    continue;
-                }
-
-                switch (msg)
-                {
-                    case Log l:
-                        _owningDispatcher.Send(_ =>
-                        {
-                            Log?.Invoke(this, new LogEventArgs(l));
-                        }, null);
-                        break;
-
-                    case DeviceAdded d:
-                        var dev = new ButtplugClientDevice(d);
-                        _devices.AddOrUpdate(d.DeviceIndex, dev, (idx, old) => dev);
-                        _owningDispatcher.Send(_ =>
-                        {
-                            DeviceAdded?.Invoke(this, new DeviceEventArgs(dev, DeviceAction.ADDED));
-                        }, null);
-                        break;
-
-                    case DeviceRemoved d:
-                        if (_devices.TryRemove(d.DeviceIndex, out ButtplugClientDevice oldDev))
-                        {
-                            _owningDispatcher.Send(_ =>
-                            {
-                                DeviceRemoved?.Invoke(this, new DeviceEventArgs(oldDev, DeviceAction.REMOVED));
-                            }, null);
-                        }
-
-                        break;
-
-                    case ScanningFinished sf:
-                        _owningDispatcher.Send(_ =>
-                        {
-                            ScanningFinished?.Invoke(this, new ScanningFinishedEventArgs(sf));
-                        }, null);
-                        break;
-
-                    case Error e:
-                        _owningDispatcher.Send(_ =>
-                        {
-                            ErrorReceived?.Invoke(this, new ErrorEventArgs(e));
-                        }, null);
-                        break;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Manages the ping timer, sending pings at the rate faster than requested by the server. If
-        /// the ping timer handler does not run, it means the event loop is blocked, and the server
-        /// will stop all devices and disconnect.
-        /// </summary>
-        /// <param name="aState">State of the Timer.</param>
-        private async void OnPingTimer(object aState)
-        {
-            try
-            {
-                var msg = await SendMessage(new Ping());
-                if (msg is Error)
-                {
-                    _owningDispatcher.Send(_ =>
-                    {
-                        ErrorReceived?.Invoke(this, new ErrorEventArgs(msg as Error));
-                    }, null);
-                    throw new Exception((msg as Error).ErrorMessage);
-                }
-            }
-            catch
-            {
-                if (_ws != null)
-                {
-                    await Disconnect();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Instructs the server to start scanning for devices. New devices will be raised as <see
-        /// cref="DeviceAdded"/> events. When scanning completes, an <see cref="ScanningFinished"/>
-        /// event will be triggered.
-        /// </summary>
-        /// <returns>
-        /// True if successful. If there are errors while the server is starting scanning, a <see
-        /// cref="ErrorReceived"/> event will be triggered.
-        /// </returns>
-        public async Task<bool> StartScanning()
-        {
-            return await SendMessageExpectOk(new StartScanning());
-        }
-
-        /// <summary>
-        /// Instructs the server to stop scanning for devices. If scanning was in progress, a <see
-        /// cref="ScanningFinished"/> event will be sent when the server has stopped scanning.
-        /// </summary>
-        /// <returns>
-        /// True if the server successful recieved the command. If there are errors while the server
-        /// is stopping scanning, a <see cref="ErrorReceived"/> event will be triggered.
-        /// </returns>
-        public async Task<bool> StopScanning()
-        {
-            return await SendMessageExpectOk(new StopScanning());
-        }
-
-        /// <summary>
-        /// Instructs the server to either forward or stop log entries to the client. Log entries
-        /// will be raised as <see cref="Log"/> events.
-        /// </summary>
-        /// <param name="aLogLevel">The maximum log level to send.</param>
-        /// <returns>
-        /// True if successful. If there are errors while the server is stopping scanning, a <see
-        /// cref="ErrorReceived"/> event will be triggered.
-        /// </returns>
-        public async Task<bool> RequestLog(string aLogLevel)
-        {
-            return await SendMessageExpectOk(new RequestLog(aLogLevel));
-        }
-
-        /// <summary>
-        /// Sends a DeviceMessage (e.g. <see cref="VibrateCmd"/> or <see cref="LinearCmd"/>). Handles
-        /// constructing some parts of the message for the user.
-        /// </summary>
-        /// <param name="aDevice">The device to be controlled by the message.</param>
-        /// <param name="aDeviceMsg">The device message (Id and DeviceIndex will be overriden).</param>
-        /// <returns>
-        /// <see cref="Ok"/> message on success, <see cref="Error"/> message with error info otherwise.
-        /// </returns>
-        public async Task<ButtplugMessage> SendDeviceMessage(ButtplugClientDevice aDevice, ButtplugDeviceMessage aDeviceMsg)
-        {
-            if (!_devices.TryGetValue(aDevice.Index, out ButtplugClientDevice dev))
-            {
-                return new Error("Device not available.", Error.ErrorClass.ERROR_DEVICE, ButtplugConsts.SystemMsgId);
-            }
-
-            if (!dev.AllowedMessages.ContainsKey(aDeviceMsg.GetType().Name))
-            {
-                return new Error("Device does not accept message type: " + aDeviceMsg.GetType().Name, Error.ErrorClass.ERROR_DEVICE, ButtplugConsts.SystemMsgId);
-            }
-
-            aDeviceMsg.DeviceIndex = aDevice.Index;
-            return await SendMessage(aDeviceMsg);
-        }
-
-        /// <summary>
-        /// Sends a message, expecting a response of message type <see cref="Ok"/>.
-        /// </summary>
-        /// <param name="aMsg">Message to send.</param>
-        /// <returns>True if successful.</returns>
-        private async Task<bool> SendMessageExpectOk(ButtplugMessage aMsg)
-        {
-            return await SendMessage(aMsg) is Ok;
+            MessageReceivedHandler(Deserialize(aArgs.Message));
         }
 
         /// <summary>
@@ -571,7 +329,7 @@ namespace Buttplug.Client
         /// </summary>
         /// <param name="aMsg">Message to send.</param>
         /// <returns>The response, which will derive from <see cref="ButtplugMessage"/>.</returns>
-        protected async Task<ButtplugMessage> SendMessage(ButtplugMessage aMsg)
+        protected override async Task<ButtplugMessage> SendMessage(ButtplugMessage aMsg)
         {
             // The client always increments the IDs on outgoing messages
             aMsg.Id = NextMsgId;
@@ -602,36 +360,6 @@ namespace Buttplug.Client
                 // Noop - WS probably closed on us during read
                 return new Error(e.Message, Error.ErrorClass.ERROR_UNKNOWN, ButtplugConsts.SystemMsgId);
             }
-        }
-
-        /// <summary>
-        /// Converts a single <see cref="ButtplugMessage"/> into a JSON string.
-        /// </summary>
-        /// <param name="aMsg">Message to convert.</param>
-        /// <returns>The JSON string representation of the message.</returns>
-        protected string Serialize(ButtplugMessage aMsg)
-        {
-            return _parser.Serialize(aMsg, ButtplugMessage.CurrentSchemaVersion);
-        }
-
-        /// <summary>
-        /// Converts an array of <see cref="ButtplugMessage"/> into a JSON string.
-        /// </summary>
-        /// <param name="aMsgs">An array of messages to convert.</param>
-        /// <returns>The JSON string representation of the messages.</returns>
-        protected string Serialize(ButtplugMessage[] aMsgs)
-        {
-            return _parser.Serialize(aMsgs, ButtplugMessage.CurrentSchemaVersion);
-        }
-
-        /// <summary>
-        /// Converts a JSON string into an array of <see cref="ButtplugMessage"/>.
-        /// </summary>
-        /// <param name="aMsg">A JSON string representing one or more messages.</param>
-        /// <returns>An array of <see cref="ButtplugMessage"/>.</returns>
-        protected ButtplugMessage[] Deserialize(string aMsg)
-        {
-            return _parser.Deserialize(aMsg);
         }
     }
 }

--- a/Buttplug.Client/IButtplugClient.cs
+++ b/Buttplug.Client/IButtplugClient.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Threading.Tasks;
+using Buttplug.Core;
+using Buttplug.Core.Messages;
+using JetBrains.Annotations;
+
+namespace Buttplug.Client
+{
+    public interface IButtplugClient
+    {
+        /// <summary>
+        /// Event fired on Buttplug device added, either after connect or while scanning for devices.
+        /// </summary>
+        [CanBeNull]
+        event EventHandler<DeviceEventArgs> DeviceAdded;
+
+        /// <summary>
+        /// Event fired on Buttplug device removed. Can fire at any time after device connection.
+        /// </summary>
+        [CanBeNull]
+        event EventHandler<DeviceEventArgs> DeviceRemoved;
+
+        /// <summary>
+        /// Event fired when the server has finished scanning for devices.
+        /// </summary>
+        [CanBeNull]
+        event EventHandler<ScanningFinishedEventArgs> ScanningFinished;
+
+        /// <summary>
+        /// Event fired when an error has been encountered. This may be internal client exceptions or
+        /// Error messages from the server.
+        /// </summary>
+        [CanBeNull]
+        event EventHandler<ErrorEventArgs> ErrorReceived;
+
+        /// <summary>
+        /// Event fired when the client receives a Log message. Should only fire if the client has
+        /// requested that log messages be sent.
+        /// </summary>
+        [CanBeNull]
+        event EventHandler<LogEventArgs> Log;
+
+        /// <summary>
+        /// Gets the connected Buttplug devices
+        /// </summary>
+        ButtplugClientDevice[] Devices { get; }
+
+        /// <summary>
+        /// Is the client connected?
+        /// </summary>
+        bool IsConnected { get; }
+
+        /// <summary>
+        /// Creates the connection to the Buttplug Server and performs the protocol hanshake.
+        /// Once the WebSocket connetion is open, the RequestServerInfo message is sent;
+        /// the response is used to set up the ping timer loop. The RequestDeviceList
+        /// message is also sent here so that any devices the server is already connected to
+        /// are made known to the client.
+        ///
+        /// <b>Important:</b> Ensure that <see cref="ButtplugWSClient.DeviceAdded"/>, <see cref="ButtplugWSClient.DeviceRemoved"/>
+        /// and <see cref="ButtplugWSClient.ErrorReceived"/> handlers are set before Connect is called.
+        /// </summary>
+        /// <param name="aURL">The URL for the Buttplug WebSocket Server. This will likely be in the form wss://localhost:12345 (wss:// is to ws:// as https:// is to http://)</param>
+        /// <param name="aIgnoreSSLErrors">When using SSL (wss://), this option prevents bad certificates from causing connection failures</param>
+        /// <returns>An untyped Task; the await/async equivelent of void</returns>
+        Task Connect(Uri aURL, bool aIgnoreSSLErrors = false);
+
+        /// <summary>
+        /// Closes the WebSocket Connection.
+        /// </summary>
+        /// <returns>An untyped Task; the await/async equivelent of void</returns>
+        Task Disconnect();
+
+        /// <summary>
+        /// Instructs the server to start scanning for devices.
+        /// New devices will be rasied as events to <see cref="ButtplugWSClient.DeviceAdded"/>.
+        /// When scanning complets, an event will be sent to <see cref="ButtplugWSClient.ScanningFinished"/>.
+        /// </summary>
+        /// <returns>True if successful.</returns>
+        Task<bool> StartScanning();
+
+        /// <summary>
+        /// Instructs the server to stop scanning for devices.
+        /// If scanning was in progress, an event will be sent to <see cref="ButtplugWSClient.ScanningFinished"/> when the device managers have all stopped scanning.
+        /// </summary>
+        /// <returns>True if the server successful recieved the command. If there are errors when stoppong the device managers, events may be sent to <see cref="ButtplugWSClient.ErrorReceived"/></returns>
+        Task<bool> StopScanning();
+
+        /// <summary>
+        /// Instructs the server to start forwarding log entries to the cleintf.
+        /// Log entries will be rasied as events to <see cref="ButtplugWSClient.Log"/>.
+        /// </summary>
+        /// <param name="aLogLevel">The level of most detailed logs to send.</param>
+        /// <returns>True if successful.</returns>
+        Task<bool> RequestLog(string aLogLevel);
+
+        /// <summary>
+        /// Sends a DeviceMessage (e.g. <see cref="VibrateCmd"/> or <see cref="LinearCmd"/>)
+        /// </summary>
+        /// <param name="aDevice">The device to be controlled by the message</param>
+        /// <param name="aDeviceMsg">The device message (Id and DeviceIndex will be overriden)</param>
+        /// <returns>True if successful.</returns>
+        Task<ButtplugMessage> SendDeviceMessage(ButtplugClientDevice aDevice, ButtplugDeviceMessage aDeviceMsg);
+    }
+}

--- a/Buttplug.Components.IPCServer/Buttplug.Components.IPCServer.csproj
+++ b/Buttplug.Components.IPCServer/Buttplug.Components.IPCServer.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A235B077-D870-49F0-9D6D-2A5D26726EFC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Buttplug.Components.IPCServer</RootNamespace>
+    <AssemblyName>Buttplug.Components.IPCServer</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\Buttplug.ProjectFiles\ButtplugCodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="JetBrains.Annotations, Version=11.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.11.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.5.0-rc03\lib\net45\NLog.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ButtplugIPCServer.cs" />
+    <Compile Include="ConnectionEventArgs.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Buttplug.Core\Buttplug.Core.csproj">
+      <Project>{FC4AF8FE-8C21-4E07-8D24-7FB7791149D0}</Project>
+      <Name>Buttplug.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Buttplug.Server\Buttplug.Server.csproj">
+      <Project>{23D9EC18-2DBA-4149-A951-B84786D4BFA6}</Project>
+      <Name>Buttplug.Server</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\Buttplug.ProjectFiles\stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.0-beta004\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.0-beta004\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Buttplug.Components.IPCServer/ButtplugIPCServer.cs
+++ b/Buttplug.Components.IPCServer/ButtplugIPCServer.cs
@@ -1,0 +1,242 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.IO.Pipes;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Buttplug.Core;
+using Buttplug.Core.Messages;
+using Buttplug.Server;
+using JetBrains.Annotations;
+using static Buttplug.Core.Messages.Error;
+
+namespace Buttplug.Components.IPCServer
+{
+    public class ButtplugIPCServer
+    {
+        [CanBeNull]
+        private NamedPipeServerStream _pipeServer;
+
+        [NotNull]
+        private IButtplugServerFactory _factory;
+
+        [NotNull]
+        private IButtplugLogManager _logManager;
+
+        [NotNull]
+        private IButtplugLog _logger;
+
+        [CanBeNull]
+        public EventHandler<UnhandledExceptionEventArgs> OnException;
+
+        [CanBeNull]
+        public EventHandler<IPCConnectionEventArgs> ConnectionAccepted;
+
+        [CanBeNull]
+        public EventHandler<IPCConnectionEventArgs> ConnectionUpdated;
+
+        [CanBeNull]
+        public EventHandler<IPCConnectionEventArgs> ConnectionClosed;
+
+        [NotNull]
+        private ConcurrentQueue<NamedPipeServerStream> _connections = new ConcurrentQueue<NamedPipeServerStream>();
+
+        [NotNull]
+        private CancellationTokenSource _cancellation;
+
+        [CanBeNull]
+        private Task _acceptThread;
+
+        public bool IsConnected => _acceptThread?.Status == TaskStatus.Running;
+
+        public void StartServer([NotNull] IButtplugServerFactory aFactory, string aPipeName = "ButtplugPipe")
+        {
+            _cancellation = new CancellationTokenSource();
+            _factory = aFactory;
+
+            _logManager = new ButtplugLogManager();
+            _logger = _logManager.GetLogger(this.GetType());
+
+            _pipeServer = new NamedPipeServerStream(aPipeName, PipeDirection.InOut, 10, PipeTransmissionMode.Message, PipeOptions.Asynchronous);
+            _acceptThread = new Task(() => { ConnectionAccepter(aPipeName, _cancellation.Token); }, _cancellation.Token, TaskCreationOptions.LongRunning);
+            _acceptThread.Start();
+        }
+
+        private async void ConnectionAccepter(string aPipeName, CancellationToken aCancellationToken)
+        {
+            while (!aCancellationToken.IsCancellationRequested)
+            {
+                await _pipeServer.WaitForConnectionAsync(aCancellationToken);
+                if (!_pipeServer.IsConnected)
+                {
+                    continue;
+                }
+
+                var temp = _pipeServer;
+                var reader = new Task(() => { AcceptIPCClientsAsync(temp, _cancellation.Token); }, _cancellation.Token,
+                    TaskCreationOptions.LongRunning);
+                reader.Start();
+
+                _pipeServer = new NamedPipeServerStream(aPipeName, PipeDirection.InOut, 10, PipeTransmissionMode.Message, PipeOptions.Asynchronous);
+            }
+        }
+
+        private async void AcceptIPCClientsAsync(NamedPipeServerStream aServer, CancellationToken aToken)
+        {
+            if (!_connections.IsEmpty)
+            {
+                try
+                {
+                    var output = Encoding.ASCII.GetBytes(new ButtplugJsonMessageParser(_logManager).Serialize(_logger.LogErrorMsg(
+                        ButtplugConsts.SystemMsgId, ErrorClass.ERROR_INIT, "WebSocketServer already in use!"), 0));
+                    aServer.Write(output, 0, output.Length);
+                    aServer.Close();
+                }
+                catch
+                {
+                    // no-op?
+                }
+                finally
+                {
+                    aServer.Dispose();
+                }
+
+                return;
+            }
+
+            _connections.Enqueue(aServer);
+            ConnectionAccepted?.Invoke(this, new IPCConnectionEventArgs());
+
+            var buttplug = _factory.GetServer();
+
+            EventHandler<MessageReceivedEventArgs> msgReceived = (aObject, aEvent) =>
+            {
+                var msg = buttplug.Serialize(aEvent.Message);
+                if (msg == null)
+                {
+                    return;
+                }
+
+                try
+                {
+                    if (aServer != null && aServer.IsConnected)
+                    {
+                        var output = Encoding.ASCII.GetBytes(msg);
+                        aServer.WriteAsync(output, 0, output.Length, aToken);
+                    }
+
+                    if (aEvent.Message is Error && (aEvent.Message as Error).ErrorCode == Error.ErrorClass.ERROR_PING && aServer != null && aServer.IsConnected)
+                    {
+                        aServer.Close();
+                    }
+                }
+                catch (WebSocketException e)
+                {
+                    // Probably means we're repling to a message we recieved just before shutdown.
+                    _logger.Error(e.Message, true);
+                }
+            };
+
+            buttplug.MessageReceived += msgReceived;
+
+            EventHandler<MessageReceivedEventArgs> clientConnected = (aObject, aEvent) =>
+            {
+                var msg = aEvent.Message as RequestServerInfo;
+                var clientName = msg?.ClientName ?? "Unknown client";
+                ConnectionUpdated?.Invoke(this, new IPCConnectionEventArgs(clientName));
+            };
+
+            buttplug.ClientConnected += clientConnected;
+
+            try
+            {
+                while (!aToken.IsCancellationRequested && aServer.IsConnected)
+                {
+                    var buffer = new byte[4096];
+                    string msg = string.Empty;
+                    var len = -1;
+                    while (len < 0 || (len == buffer.Length && buffer[4095] != '\0'))
+                    {
+                        try
+                        {
+                            len = await aServer.ReadAsync(buffer, 0, buffer.Length, aToken);
+                            if (len > 0)
+                            {
+                                msg += Encoding.ASCII.GetString(buffer, 0, len);
+                            }
+                        }
+                        catch
+                        {
+                            // no-op?
+                        }
+                    }
+
+                    if (msg.Length > 0)
+                    {
+                        var respMsgs = await buttplug.SendMessage(msg);
+                        var respMsg = buttplug.Serialize(respMsgs);
+                        if (respMsg == null)
+                        {
+                            continue;
+                        }
+
+                        var output = Encoding.ASCII.GetBytes(respMsg);
+                        await aServer.WriteAsync(output, 0, output.Length, aToken);
+
+                        foreach (var m in respMsgs)
+                        {
+                            if (m is Error && (m as Error).ErrorCode == Error.ErrorClass.ERROR_PING && aServer.IsConnected)
+                            {
+                                aServer.Close();
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e.Message, true);
+                try
+                {
+                    aServer.Close();
+                }
+                catch
+                {
+                    // noop
+                }
+            }
+            finally
+            {
+                buttplug.MessageReceived -= msgReceived;
+                await buttplug.Shutdown();
+                buttplug = null;
+                _connections.TryDequeue(out var stashed);
+                while (stashed != aServer && _connections.Any())
+                {
+                    _connections.Enqueue(stashed);
+                    _connections.TryDequeue(out stashed);
+                }
+
+                aServer.Dispose();
+                aServer = null;
+                ConnectionClosed?.Invoke(this, new IPCConnectionEventArgs());
+            }
+        }
+
+        public void StopServer()
+        {
+            _cancellation.Cancel();
+            _pipeServer = null;
+        }
+
+        public void Disconnect()
+        {
+            foreach (var conn in _connections)
+            {
+                conn.Close();
+            }
+        }
+    }
+}

--- a/Buttplug.Components.IPCServer/ConnectionEventArgs.cs
+++ b/Buttplug.Components.IPCServer/ConnectionEventArgs.cs
@@ -1,0 +1,15 @@
+﻿using JetBrains.Annotations;
+
+namespace Buttplug.Components.IPCServer
+{
+    public class IPCConnectionEventArgs
+    {
+        [NotNull]
+        public string ClientName;
+
+        public IPCConnectionEventArgs(string aClientName = "Unknown Client")
+        {
+            ClientName = aClientName;
+        }
+    }
+}

--- a/Buttplug.Components.IPCServer/Properties/AssemblyInfo.cs
+++ b/Buttplug.Components.IPCServer/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Buttplug.Components.IPCServer")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Buttplug.Components.IPCServer")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a235b077-d870-49f0-9d6d-2a5d26726efc")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Buttplug.Components.IPCServer/app.config
+++ b/Buttplug.Components.IPCServer/app.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7"/></startup></configuration>

--- a/Buttplug.Components.IPCServer/packages.config
+++ b/Buttplug.Components.IPCServer/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="JetBrains.Annotations" version="11.1.0" targetFramework="net452" />
+  <package id="NLog" version="4.5.0-rc03" targetFramework="net452" />
+  <package id="StyleCop.Analyzers" version="1.1.0-beta004" targetFramework="net452" developmentDependency="true" />
+</packages>

--- a/Buttplug.sln
+++ b/Buttplug.sln
@@ -51,6 +51,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Buttplug.Server.Managers.Wi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Buttplug.Server.Managers.HidManager", "Buttplug.Server.Managers.HidManager\Buttplug.Server.Managers.HidManager.csproj", "{83574729-6EB4-43E9-B7CC-AC5725380038}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Buttplug.Components.IPCServer", "Buttplug.Components.IPCServer\Buttplug.Components.IPCServer.csproj", "{A235B077-D870-49F0-9D6D-2A5D26726EFC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -151,6 +153,10 @@ Global
 		{0F5DAB4B-184B-4B7E-9F40-339C7F5E216F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F5DAB4B-184B-4B7E-9F40-339C7F5E216F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0F5DAB4B-184B-4B7E-9F40-339C7F5E216F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A235B077-D870-49F0-9D6D-2A5D26726EFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A235B077-D870-49F0-9D6D-2A5D26726EFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A235B077-D870-49F0-9D6D-2A5D26726EFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A235B077-D870-49F0-9D6D-2A5D26726EFC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This set of changes implements IPC in the form of Buttplug over named pipes (the Windows equivalent of domain sockets).

The client work for this forced the issue of abstracting the transport method from the rest of the implementation: the message handling is identical regardless of how the messages are actually sent between the server and client. This fixes #367 

The GUI changes to support this leave a lot to be desired, but this is first a PoC.

ToDo:
* need to confirm that the abstraction route is the correct one.
* need to update the abstracted comments.
* need to add tests