### PR TITLE
Bluetooth capability addition and Lovense fix

### DIFF
--- a/Buttplug.Server.Test/TestBluetoothDeviceInterface.cs
+++ b/Buttplug.Server.Test/TestBluetoothDeviceInterface.cs
@@ -43,6 +43,8 @@ namespace Buttplug.Server.Test
 
         public event EventHandler ValueWritten;
 
+        public event EventHandler<BluetoothNotifyEventArgs> BluetoothNotifyReceived;
+
         public bool Removed;
 
         public TestBluetoothDeviceInterface(string aName)

--- a/Buttplug.Server/Bluetooth/BluetoothNotifyEventArgs.cs
+++ b/Buttplug.Server/Bluetooth/BluetoothNotifyEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Buttplug.Server.Bluetooth
+{
+    public class BluetoothNotifyEventArgs : EventArgs
+    {
+        public byte[] bytes { get; }
+
+        public BluetoothNotifyEventArgs(byte[] aBytes)
+        {
+            bytes = aBytes;
+        }
+    }
+}

--- a/Buttplug.Server/Bluetooth/IBluetoothDeviceInterface.cs
+++ b/Buttplug.Server/Bluetooth/IBluetoothDeviceInterface.cs
@@ -8,6 +8,8 @@ namespace Buttplug.Server.Bluetooth
     {
         string Name { get; }
 
+        event EventHandler<BluetoothNotifyEventArgs> BluetoothNotifyReceived;
+
         Task<ButtplugMessage> WriteValue(uint aMsgId, byte[] aValue, bool aWriteWithResponse = false);
 
         Task<ButtplugMessage> WriteValue(uint aMsgId, uint aCharactieristicIndex, byte[] aValue, bool aWriteWithResponse = false);


### PR DESCRIPTION
The existing Bluetooth interface doesn't quite support notify. SubscribeToUpdates() will tell the server you're interested, but nothing ever subscribes to the event to receive the messages. This adds an event (BluetoothNotifyReceived) to fill that hole. Conversion to a byte array is handled internally for convenience. (Won't work for indexed characteristics as things stand, but I don't have a device to test that with anyway.)

And then that's used to fix Lovense device identification. Since read performs quickly on supported devices, that's done first, and if that fails it waits for a bit to see if a message will come in. It's usually much faster than half a second, but the timing does vary, so I used a loop rather than a fixed delay time.

At least for the device I have, subscribing to indicate was not required, and could be undesirable for performance reasons from what I've read.

Also added the "convert C to A" to to the type checking, and changed a trace message to what it looks like it was supposed to be.