### PR TITLE
build: Update dependencies and add missing references

### DIFF
--- a/Buttplug.Apps.GameVibrationRouter.GUI/Buttplug.Apps.GameVibrationRouter.GUI.csproj
+++ b/Buttplug.Apps.GameVibrationRouter.GUI/Buttplug.Apps.GameVibrationRouter.GUI.csproj
@@ -54,11 +54,11 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema, Version=9.10.67.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>..\packages\NJsonSchema.9.10.67\lib\net45\NJsonSchema.dll</HintPath>
+    <Reference Include="NJsonSchema, Version=9.10.70.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>..\packages\NJsonSchema.9.10.70\lib\net45\NJsonSchema.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.5.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -69,6 +69,9 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.9.0\lib\netstandard2.0\System.Threading.Tasks.Dataflow.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />

--- a/Buttplug.Apps.GameVibrationRouter.GUI/packages.config
+++ b/Buttplug.Apps.GameVibrationRouter.GUI/packages.config
@@ -5,6 +5,7 @@
   <package id="LiveCharts" version="0.9.7" targetFramework="net461" />
   <package id="LiveCharts.Wpf" version="0.9.7" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
-  <package id="NJsonSchema" version="9.10.67" targetFramework="net47" />
-  <package id="NLog" version="4.5.8" targetFramework="net47" />
+  <package id="NJsonSchema" version="9.10.70" targetFramework="net47" />
+  <package id="NLog" version="4.5.9" targetFramework="net47" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.9.0" targetFramework="net47" />
 </packages>

--- a/Buttplug.Apps.ServerGUI.Test/Buttplug.Apps.ServerGUI.Test.csproj
+++ b/Buttplug.Apps.ServerGUI.Test/Buttplug.Apps.ServerGUI.Test.csproj
@@ -44,11 +44,11 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema, Version=9.10.67.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>..\packages\NJsonSchema.9.10.67\lib\net45\NJsonSchema.dll</HintPath>
+    <Reference Include="NJsonSchema, Version=9.10.70.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>..\packages\NJsonSchema.9.10.70\lib\net45\NJsonSchema.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.5.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>

--- a/Buttplug.Apps.ServerGUI.Test/packages.config
+++ b/Buttplug.Apps.ServerGUI.Test/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="deniszykov.WebSocketListener" version="4.2.4" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
-  <package id="NJsonSchema" version="9.10.67" targetFramework="net47" />
-  <package id="NLog" version="4.5.8" targetFramework="net47" />
+  <package id="NJsonSchema" version="9.10.70" targetFramework="net47" />
+  <package id="NLog" version="4.5.9" targetFramework="net47" />
   <package id="NUnit" version="3.10.1" targetFramework="net47" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net47" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta004" targetFramework="net452" developmentDependency="true" />

--- a/Buttplug.Apps.ServerGUI/App.config
+++ b/Buttplug.Apps.ServerGUI/App.config
@@ -13,6 +13,10 @@
         <assemblyIdentity name="System.Threading.Tasks.Dataflow" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.6.3.0" newVersion="4.6.3.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Buttplug.Apps.ServerGUI/Buttplug.Apps.ServerGUI.csproj
+++ b/Buttplug.Apps.ServerGUI/Buttplug.Apps.ServerGUI.csproj
@@ -41,17 +41,20 @@
     <ApplicationIcon>Resources\buttplug-icon-1.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="deniszykov.WebSocketListener, Version=4.2.4.0, Culture=neutral, PublicKeyToken=7f78616efb4a208d, processorArchitecture=MSIL">
+      <HintPath>..\packages\deniszykov.WebSocketListener.4.2.4\lib\net45\deniszykov.WebSocketListener.dll</HintPath>
+    </Reference>
     <Reference Include="JetBrains.Annotations, Version=2018.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
       <HintPath>..\packages\JetBrains.Annotations.2018.2.1\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema, Version=9.10.67.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>..\packages\NJsonSchema.9.10.67\lib\net45\NJsonSchema.dll</HintPath>
+    <Reference Include="NJsonSchema, Version=9.10.70.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>..\packages\NJsonSchema.9.10.70\lib\net45\NJsonSchema.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.5.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -60,6 +63,9 @@
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Dataflow.4.9.0\lib\netstandard2.0\System.Threading.Tasks.Dataflow.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xaml" />
     <Reference Include="Microsoft.CSharp" />

--- a/Buttplug.Apps.ServerGUI/packages.config
+++ b/Buttplug.Apps.ServerGUI/packages.config
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="deniszykov.WebSocketListener" version="4.2.4" targetFramework="net47" />
   <package id="JetBrains.Annotations" version="2018.2.1" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
-  <package id="NJsonSchema" version="9.10.67" targetFramework="net47" />
-  <package id="NLog" version="4.5.8" targetFramework="net47" />
+  <package id="NJsonSchema" version="9.10.70" targetFramework="net47" />
+  <package id="NLog" version="4.5.9" targetFramework="net47" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta004" targetFramework="net452" developmentDependency="true" />
+  <package id="System.Threading.Tasks.Dataflow" version="4.9.0" targetFramework="net47" />
 </packages>

--- a/Buttplug.Client.Connectors.IPCConnector.Test/Buttplug.Client.Connectors.IPCConnector.Test.csproj
+++ b/Buttplug.Client.Connectors.IPCConnector.Test/Buttplug.Client.Connectors.IPCConnector.Test.csproj
@@ -38,8 +38,8 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema, Version=9.10.67.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>..\packages\NJsonSchema.9.10.67\lib\net45\NJsonSchema.dll</HintPath>
+    <Reference Include="NJsonSchema, Version=9.10.70.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>..\packages\NJsonSchema.9.10.70\lib\net45\NJsonSchema.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>

--- a/Buttplug.Client.Connectors.IPCConnector.Test/packages.config
+++ b/Buttplug.Client.Connectors.IPCConnector.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
-  <package id="NJsonSchema" version="9.10.67" targetFramework="net47" />
+  <package id="NJsonSchema" version="9.10.70" targetFramework="net47" />
   <package id="NUnit" version="3.10.1" targetFramework="net47" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net47" />
 </packages>

--- a/Buttplug.Client.Connectors.WebsocketConnector.Test/Buttplug.Client.Connectors.WebsocketConnector.Test.csproj
+++ b/Buttplug.Client.Connectors.WebsocketConnector.Test/Buttplug.Client.Connectors.WebsocketConnector.Test.csproj
@@ -38,8 +38,8 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema, Version=9.10.67.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>..\packages\NJsonSchema.9.10.67\lib\net45\NJsonSchema.dll</HintPath>
+    <Reference Include="NJsonSchema, Version=9.10.70.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>..\packages\NJsonSchema.9.10.70\lib\net45\NJsonSchema.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>

--- a/Buttplug.Client.Connectors.WebsocketConnector.Test/packages.config
+++ b/Buttplug.Client.Connectors.WebsocketConnector.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
-  <package id="NJsonSchema" version="9.10.67" targetFramework="net47" />
+  <package id="NJsonSchema" version="9.10.70" targetFramework="net47" />
   <package id="NUnit" version="3.10.1" targetFramework="net47" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net47" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net47" />

--- a/Buttplug.Client.Test/Buttplug.Client.Test.csproj
+++ b/Buttplug.Client.Test/Buttplug.Client.Test.csproj
@@ -44,11 +44,11 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema, Version=9.10.67.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>..\packages\NJsonSchema.9.10.67\lib\net45\NJsonSchema.dll</HintPath>
+    <Reference Include="NJsonSchema, Version=9.10.70.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>..\packages\NJsonSchema.9.10.70\lib\net45\NJsonSchema.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.5.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>

--- a/Buttplug.Client.Test/packages.config
+++ b/Buttplug.Client.Test/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="JetBrains.Annotations" version="2018.2.1" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
-  <package id="NJsonSchema" version="9.10.67" targetFramework="net47" />
-  <package id="NLog" version="4.5.8" targetFramework="net47" />
+  <package id="NJsonSchema" version="9.10.70" targetFramework="net47" />
+  <package id="NLog" version="4.5.9" targetFramework="net47" />
   <package id="NUnit" version="3.10.1" targetFramework="net47" />
   <package id="NUnit.ConsoleRunner" version="3.8.0" targetFramework="net47" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net47" />

--- a/Buttplug.Client/Buttplug.Client.csproj
+++ b/Buttplug.Client/Buttplug.Client.csproj
@@ -40,7 +40,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" version="2018.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NLog" version="4.5.8" />
+    <PackageReference Include="NLog" version="4.5.9" />
     <PackageReference Include="StyleCop.Analyzers" version="1.1.0-beta004" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
   </ItemGroup>

--- a/Buttplug.Components.Controls/Buttplug.Components.Controls.csproj
+++ b/Buttplug.Components.Controls/Buttplug.Components.Controls.csproj
@@ -41,7 +41,7 @@
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.5.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="SharpRaven, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpRaven.2.4.0\lib\net45\SharpRaven.dll</HintPath>

--- a/Buttplug.Components.Controls/app.config
+++ b/Buttplug.Components.Controls/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" /></startup></configuration>

--- a/Buttplug.Components.Controls/packages.config
+++ b/Buttplug.Components.Controls/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="JetBrains.Annotations" version="2018.2.1" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
-  <package id="NLog" version="4.5.8" targetFramework="net47" />
+  <package id="NLog" version="4.5.9" targetFramework="net47" />
   <package id="SharpRaven" version="2.4.0" targetFramework="net47" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta004" targetFramework="net452" developmentDependency="true" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net47" />

--- a/Buttplug.Core.Test/Buttplug.Core.Test.csproj
+++ b/Buttplug.Core.Test/Buttplug.Core.Test.csproj
@@ -38,8 +38,8 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema, Version=9.10.67.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>..\packages\NJsonSchema.9.10.67\lib\net45\NJsonSchema.dll</HintPath>
+    <Reference Include="NJsonSchema, Version=9.10.70.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>..\packages\NJsonSchema.9.10.70\lib\net45\NJsonSchema.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>

--- a/Buttplug.Core.Test/packages.config
+++ b/Buttplug.Core.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
-  <package id="NJsonSchema" version="9.10.67" targetFramework="net47" />
+  <package id="NJsonSchema" version="9.10.70" targetFramework="net47" />
   <package id="NUnit" version="3.10.1" targetFramework="net47" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net47" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta004" targetFramework="net47" developmentDependency="true" />

--- a/Buttplug.Core/Buttplug.Core.csproj
+++ b/Buttplug.Core/Buttplug.Core.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="JetBrains.Annotations" version="2018.2.1" />
     <PackageReference Include="LibLog" Version="5.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NJsonSchema" version="9.10.67" />
+    <PackageReference Include="NJsonSchema" version="9.10.70" />
     <!-- <PackageReference Include="StyleCop.Analyzers" version="1.1.0-beta004" PrivateAssets="All" /> -->
     <PackageReference Include="Microsoft.CSharp" version="4.5.0" />
   </ItemGroup>

--- a/Buttplug.Server.Managers.UWPBluetoothManager/Buttplug.Server.Managers.UWPBluetoothManager.csproj
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/Buttplug.Server.Managers.UWPBluetoothManager.csproj
@@ -38,7 +38,7 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.5.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Buttplug.Server.Managers.UWPBluetoothManager/packages.config
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="JetBrains.Annotations" version="2018.2.1" targetFramework="net47" />
-  <package id="NLog" version="4.5.8" targetFramework="net47" />
+  <package id="NLog" version="4.5.9" targetFramework="net47" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta004" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/Buttplug.Server.Managers.XInputGamepadManager/Buttplug.Server.Managers.XInputGamepadManager.csproj
+++ b/Buttplug.Server.Managers.XInputGamepadManager/Buttplug.Server.Managers.XInputGamepadManager.csproj
@@ -36,13 +36,13 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.5.9\lib\net45\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.4.1.0\lib\net45\SharpDX.dll</HintPath>
+    <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.XInput, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.XInput.4.1.0\lib\net45\SharpDX.XInput.dll</HintPath>
+    <Reference Include="SharpDX.XInput, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.XInput.4.2.0\lib\net45\SharpDX.XInput.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/Buttplug.Server.Managers.XInputGamepadManager/packages.config
+++ b/Buttplug.Server.Managers.XInputGamepadManager/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="4.5.8" targetFramework="net47" />
-  <package id="SharpDX" version="4.1.0" targetFramework="net47" />
-  <package id="SharpDX.XInput" version="4.1.0" targetFramework="net47" />
+  <package id="NLog" version="4.5.9" targetFramework="net47" />
+  <package id="SharpDX" version="4.2.0" targetFramework="net47" />
+  <package id="SharpDX.XInput" version="4.2.0" targetFramework="net47" />
   <package id="StyleCop.Analyzers" version="1.1.0-beta004" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/Buttplug.Server.Test/Buttplug.Server.Test.csproj
+++ b/Buttplug.Server.Test/Buttplug.Server.Test.csproj
@@ -50,11 +50,11 @@
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NJsonSchema, Version=9.10.67.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-      <HintPath>..\packages\NJsonSchema.9.10.67\lib\net45\NJsonSchema.dll</HintPath>
+    <Reference Include="NJsonSchema, Version=9.10.70.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>..\packages\NJsonSchema.9.10.70\lib\net45\NJsonSchema.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.4.5.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.5.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>

--- a/Buttplug.Server.Test/packages.config
+++ b/Buttplug.Server.Test/packages.config
@@ -4,8 +4,8 @@
   <package id="Microsoft.CodeCoverage" version="15.8.0" targetFramework="net47" />
   <package id="Microsoft.NET.Test.Sdk" version="15.8.0" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
-  <package id="NJsonSchema" version="9.10.67" targetFramework="net47" />
-  <package id="NLog" version="4.5.8" targetFramework="net47" />
+  <package id="NJsonSchema" version="9.10.70" targetFramework="net47" />
+  <package id="NLog" version="4.5.9" targetFramework="net47" />
   <package id="NUnit" version="3.10.1" targetFramework="net47" />
   <package id="NUnit.ConsoleRunner" version="3.8.0" targetFramework="net47" />
   <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net47" />

--- a/Buttplug.Server/Buttplug.Server.csproj
+++ b/Buttplug.Server/Buttplug.Server.csproj
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" version="2018.2.1" />
-    <PackageReference Include="NLog" version="4.5.8" />
+    <PackageReference Include="NLog" version="4.5.9" />
     <PackageReference Include="StyleCop.Analyzers" version="1.1.0-beta004" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Timer" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />


### PR DESCRIPTION
Due to project type changes, WPF projects aren't inheriting
dependencies from libraries. This should get fixed in #464, but for
now, just add what is needed and upgrade other packages while we're at it.