### PR TITLE
chore: Correcting the namespaces Core classes

### DIFF
--- a/Buttplug.Apps.ServerGUI/ServerControl.xaml.cs
+++ b/Buttplug.Apps.ServerGUI/ServerControl.xaml.cs
@@ -21,6 +21,7 @@ using Buttplug.Server.Connectors.WebsocketServer;
 using JetBrains.Annotations;
 using Microsoft.Win32;
 using Windows.UI.Notifications;
+using Buttplug.Core.Logging;
 
 namespace Buttplug.Apps.ServerGUI
 {

--- a/Buttplug.Client.Connectors.IPCConnector.Test/ButtplugClientIPCConnectorTests.cs
+++ b/Buttplug.Client.Connectors.IPCConnector.Test/ButtplugClientIPCConnectorTests.cs
@@ -1,5 +1,6 @@
 ﻿using Buttplug.Client.Test;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Test;
 using Buttplug.Server.Connectors.IPCServer;
 using Buttplug.Server.Test;

--- a/Buttplug.Client.Connectors.WebsocketConnector.Test/ButtplugClientWebsocketConnectorTests.cs
+++ b/Buttplug.Client.Connectors.WebsocketConnector.Test/ButtplugClientWebsocketConnectorTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Buttplug.Client.Test;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Test;
 using Buttplug.Server.Connectors.WebsocketServer;
 using Buttplug.Server.Test;

--- a/Buttplug.Client.Connectors.WebsocketConnector/ButtplugWebsocketConnector.cs
+++ b/Buttplug.Client.Connectors.WebsocketConnector/ButtplugWebsocketConnector.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
+using Buttplug.Core.Messages;
 using vtortola.WebSockets;
 using vtortola.WebSockets.Rfc6455;
 

--- a/Buttplug.Client.Test/ArgsTests.cs
+++ b/Buttplug.Client.Test/ArgsTests.cs
@@ -32,9 +32,9 @@ namespace Buttplug.Client.Test
         [Test]
         public void LogEventArgsTest()
         {
-            var arg = new LogEventArgs(new Core.Messages.Log(Core.ButtplugLogLevel.Debug, "test"));
+            var arg = new LogEventArgs(new Core.Messages.Log(Core.Logging.ButtplugLogLevel.Debug, "test"));
             Assert.AreEqual("test", arg.Message.LogMessage);
-            Assert.AreEqual(Core.ButtplugLogLevel.Debug, arg.Message.LogLevel);
+            Assert.AreEqual(Core.Logging.ButtplugLogLevel.Debug, arg.Message.LogLevel);
         }
     }
 }

--- a/Buttplug.Client.Test/ButtplugClientConnectorTestBase.cs
+++ b/Buttplug.Client.Test/ButtplugClientConnectorTestBase.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using Buttplug.Server.Test;
 using NUnit.Framework;

--- a/Buttplug.Client/ButtplugClient.cs
+++ b/Buttplug.Client/ButtplugClient.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 

--- a/Buttplug.Client/ButtplugClientException.cs
+++ b/Buttplug.Client/ButtplugClientException.cs
@@ -6,6 +6,7 @@
 
 using System;
 using Buttplug.Core;
+using Buttplug.Core.Messages;
 
 namespace Buttplug.Client
 {

--- a/Buttplug.Client/ButtplugConnectorJSONParser.cs
+++ b/Buttplug.Client/ButtplugConnectorJSONParser.cs
@@ -5,10 +5,13 @@
 // </copyright>
 
 using Buttplug.Core;
+using Buttplug.Core.Logging;
+using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 
 namespace Buttplug.Client
 {
+    // ReSharper disable once InconsistentNaming
     public class ButtplugConnectorJSONParser
     {
         /// <summary>

--- a/Buttplug.Client/ButtplugConnectorMessageSorter.cs
+++ b/Buttplug.Client/ButtplugConnectorMessageSorter.cs
@@ -9,6 +9,7 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 
 namespace Buttplug.Client

--- a/Buttplug.Client/ButtplugEmbeddedConnector.cs
+++ b/Buttplug.Client/ButtplugEmbeddedConnector.cs
@@ -8,6 +8,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Messages;
 using Buttplug.Server;
 
 namespace Buttplug.Client

--- a/Buttplug.Client/ButtplugRemoteJSONConnector.cs
+++ b/Buttplug.Client/ButtplugRemoteJSONConnector.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Messages;
 
 namespace Buttplug.Client
 {

--- a/Buttplug.Client/IButtplugClientConnector.cs
+++ b/Buttplug.Client/IButtplugClientConnector.cs
@@ -8,6 +8,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Messages;
 
 namespace Buttplug.Client
 {

--- a/Buttplug.Components.Controls/ButtplugAboutControl.xaml.cs
+++ b/Buttplug.Components.Controls/ButtplugAboutControl.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using JetBrains.Annotations;
 using Newtonsoft.Json.Linq;
 using Application = System.Windows.Application;

--- a/Buttplug.Components.Controls/ButtplugLogControl.xaml.cs
+++ b/Buttplug.Components.Controls/ButtplugLogControl.xaml.cs
@@ -13,10 +13,12 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Microsoft.Win32;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
+using LogLevel = NLog.LogLevel;
 
 namespace Buttplug.Components.Controls
 {

--- a/Buttplug.Core.Test/ButtplugDeviceTests.cs
+++ b/Buttplug.Core.Test/ButtplugDeviceTests.cs
@@ -7,6 +7,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using NUnit.Framework;
 

--- a/Buttplug.Core.Test/ButtplugJsonMessageParserTests.cs
+++ b/Buttplug.Core.Test/ButtplugJsonMessageParserTests.cs
@@ -4,6 +4,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using NUnit.Framework;
 

--- a/Buttplug.Core.Test/ButtplugMessagesTests.cs
+++ b/Buttplug.Core.Test/ButtplugMessagesTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using NUnit.Framework;
 

--- a/Buttplug.Core.Test/TestDevice.cs
+++ b/Buttplug.Core.Test/TestDevice.cs
@@ -7,6 +7,8 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 
 namespace Buttplug.Core.Test

--- a/Buttplug.Core/ButtplugJsonMessageParser.cs
+++ b/Buttplug.Core/ButtplugJsonMessageParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 using Newtonsoft.Json;

--- a/Buttplug.Core/Devices/ButtplugDevice.cs
+++ b/Buttplug.Core/Devices/ButtplugDevice.cs
@@ -2,11 +2,12 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 using static Buttplug.Core.Messages.Error;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Devices
 {
     /// <summary>
     /// Abstract representation of a device

--- a/Buttplug.Core/Devices/ButtplugDeviceMessage.cs
+++ b/Buttplug.Core/Devices/ButtplugDeviceMessage.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using Buttplug.Core.Messages;
 using Newtonsoft.Json;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Devices
 {
     /// <summary>
     /// Subclass of Buttplug Messages, that command a device to take an action.

--- a/Buttplug.Core/Devices/ButtplugDeviceMessageHandler.cs
+++ b/Buttplug.Core/Devices/ButtplugDeviceMessageHandler.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Devices
 {
     /// <summary>
     /// A container class for message functions and attributes

--- a/Buttplug.Core/Devices/IButtplugDevice.cs
+++ b/Buttplug.Core/Devices/IButtplugDevice.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Devices
 {
     /// <summary>
     /// Interface for representations of hardware devices.

--- a/Buttplug.Core/Logging/ButtplugLog.cs
+++ b/Buttplug.Core/Logging/ButtplugLog.cs
@@ -2,7 +2,7 @@
 using Buttplug.Core.Logging;
 using JetBrains.Annotations;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Logging
 {
     internal class ButtplugLog : IButtplugLog
     {

--- a/Buttplug.Core/Logging/ButtplugLogExtensions.cs
+++ b/Buttplug.Core/Logging/ButtplugLogExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Logging
 {
     /// <summary>
     /// Extension methods for <see cref="IButtplugLog"/>.

--- a/Buttplug.Core/Logging/ButtplugLogLevel.cs
+++ b/Buttplug.Core/Logging/ButtplugLogLevel.cs
@@ -1,4 +1,4 @@
-﻿namespace Buttplug.Core
+﻿namespace Buttplug.Core.Logging
 {
     /// <summary>
     /// Logging levels used by the <see cref="ButtplugLog"/>

--- a/Buttplug.Core/Logging/ButtplugLogManager.cs
+++ b/Buttplug.Core/Logging/ButtplugLogManager.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using Buttplug.Core.Logging;
 using JetBrains.Annotations;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Logging
 {
     /// <summary>
     /// Handles receiving log messages and reporting any that match requested granuarlity levels

--- a/Buttplug.Core/Logging/ButtplugLogMessageEventArgs.cs
+++ b/Buttplug.Core/Logging/ButtplugLogMessageEventArgs.cs
@@ -2,7 +2,7 @@
 using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Logging
 {
     /// <summary>
     /// Event wrapper for log message events.

--- a/Buttplug.Core/Logging/IButtplugLog.cs
+++ b/Buttplug.Core/Logging/IButtplugLog.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using JetBrains.Annotations;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Logging
 {
     /// <summary>
     /// Sets up a common interface for log message events.

--- a/Buttplug.Core/Logging/IButtplugLogManager.cs
+++ b/Buttplug.Core/Logging/IButtplugLogManager.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using JetBrains.Annotations;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Logging
 {
     /// <summary>
     /// Interface for log managers. See <see cref="ButtplugLogManager"/> implementation for more info.

--- a/Buttplug.Core/Logging/LogExceptionEventArgs.cs
+++ b/Buttplug.Core/Logging/LogExceptionEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Logging
 {
     /// <summary>
     /// Event wrapper for an exception log message

--- a/Buttplug.Core/Messages/ButtplugMessage.cs
+++ b/Buttplug.Core/Messages/ButtplugMessage.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using Buttplug.Core.Messages;
 using Newtonsoft.Json;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Messages
 {
     /// <summary>
     /// Base class for Buttplug protocol messages.

--- a/Buttplug.Core/Messages/MessageReceivedEventArgs.cs
+++ b/Buttplug.Core/Messages/MessageReceivedEventArgs.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Buttplug.Core
+namespace Buttplug.Core.Messages
 {
     /// <summary>
     /// Event fired when a new <see cref="ButtplugMessage"/> is received.

--- a/Buttplug.Core/Messages/Messages.cs
+++ b/Buttplug.Core/Messages/Messages.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Newtonsoft.Json;
 
 // Namespace containing all Buttplug messages, as specified by the Buttplug Message Spec at

--- a/Buttplug.Server.Connectors.IPCServer/ButtplugIPCServer.cs
+++ b/Buttplug.Server.Connectors.IPCServer/ButtplugIPCServer.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using Buttplug.Server;
 using JetBrains.Annotations;

--- a/Buttplug.Server.Connectors.WebsocketServer/ButtplugWebsocketServer.cs
+++ b/Buttplug.Server.Connectors.WebsocketServer/ButtplugWebsocketServer.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using JetBrains.Annotations;
 using vtortola.WebSockets;
 using vtortola.WebSockets.Rfc6455;

--- a/Buttplug.Server.Connectors.WebsocketServer/ButtplugWebsocketServerSession.cs
+++ b/Buttplug.Server.Connectors.WebsocketServer/ButtplugWebsocketServerSession.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 using vtortola.WebSockets;

--- a/Buttplug.Server.Managers.ETSerialManager/ET312Device.cs
+++ b/Buttplug.Server.Managers.ETSerialManager/ET312Device.cs
@@ -11,6 +11,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using Buttplug.Server.Util;
 using static Buttplug.Server.Managers.ETSerialManager.ET312Protocol;

--- a/Buttplug.Server.Managers.ETSerialManager/ETSerialManager.cs
+++ b/Buttplug.Server.Managers.ETSerialManager/ETSerialManager.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.IO.Ports;
 using System.Threading;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using static Buttplug.Server.Managers.ETSerialManager.ET312Protocol;
 
 // ReSharper disable once CheckNamespace

--- a/Buttplug.Server.Managers.HidManager/Devices/CycloneX10.cs
+++ b/Buttplug.Server.Managers.HidManager/Devices/CycloneX10.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using HidLibrary;
 

--- a/Buttplug.Server.Managers.HidManager/HidButtplugDevice.cs
+++ b/Buttplug.Server.Managers.HidManager/HidButtplugDevice.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using HidLibrary;
 
 namespace Buttplug.Server.Managers.HidManager

--- a/Buttplug.Server.Managers.HidManager/HidDeviceFactory.cs
+++ b/Buttplug.Server.Managers.HidManager/HidDeviceFactory.cs
@@ -5,6 +5,8 @@
 // </copyright>
 
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using HidLibrary;
 
 namespace Buttplug.Server.Managers.HidManager

--- a/Buttplug.Server.Managers.HidManager/HidManager.cs
+++ b/Buttplug.Server.Managers.HidManager/HidManager.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Server.Managers.HidManager.Devices;
 using HidLibrary;
 

--- a/Buttplug.Server.Managers.HidManager/IHidDeviceInfo.cs
+++ b/Buttplug.Server.Managers.HidManager/IHidDeviceInfo.cs
@@ -5,6 +5,8 @@
 // </copyright>
 
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using HidLibrary;
 
 namespace Buttplug.Server.Managers.HidManager

--- a/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceFactory.cs
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceFactory.cs
@@ -14,6 +14,8 @@ using Buttplug.Server.Bluetooth;
 using JetBrains.Annotations;
 using Windows.Devices.Bluetooth;
 using Windows.Devices.Bluetooth.GenericAttributeProfile;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 
 namespace Buttplug.Server.Managers.UWPBluetoothManager
 {

--- a/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceInterface.cs
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceInterface.cs
@@ -17,6 +17,7 @@ using JetBrains.Annotations;
 using Windows.Devices.Bluetooth;
 using Windows.Devices.Bluetooth.GenericAttributeProfile;
 using Windows.Security.Cryptography;
+using Buttplug.Core.Logging;
 
 namespace Buttplug.Server.Managers.UWPBluetoothManager
 {

--- a/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothManager.cs
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothManager.cs
@@ -14,6 +14,7 @@ using JetBrains.Annotations;
 using Microsoft.Win32;
 using Windows.Devices.Bluetooth;
 using Windows.Devices.Bluetooth.Advertisement;
+using Buttplug.Core.Logging;
 
 namespace Buttplug.Server.Managers.UWPBluetoothManager
 {

--- a/Buttplug.Server.Managers.WinUSBManager/RezTranceVibratorDevice.cs
+++ b/Buttplug.Server.Managers.WinUSBManager/RezTranceVibratorDevice.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using MadWizard.WinUSBNet;
 

--- a/Buttplug.Server.Managers.WinUSBManager/WinUSBManager.cs
+++ b/Buttplug.Server.Managers.WinUSBManager/WinUSBManager.cs
@@ -6,6 +6,7 @@
 
 using System;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using MadWizard.WinUSBNet;
 using Microsoft.Win32;
 

--- a/Buttplug.Server.Managers.XInputGamepadManager/XInputGamepadDevice.cs
+++ b/Buttplug.Server.Managers.XInputGamepadManager/XInputGamepadDevice.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using SharpDX.XInput;
 

--- a/Buttplug.Server.Managers.XInputGamepadManager/XInputGamepadManager.cs
+++ b/Buttplug.Server.Managers.XInputGamepadManager/XInputGamepadManager.cs
@@ -6,6 +6,7 @@
 
 using System;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using SharpDX.XInput;
 
 namespace Buttplug.Server.Managers.XInputGamepadManager

--- a/Buttplug.Server.Test/ArgsTests.cs
+++ b/Buttplug.Server.Test/ArgsTests.cs
@@ -6,6 +6,8 @@
 
 using System;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
+using Buttplug.Core.Messages;
 using NUnit.Framework;
 
 namespace Buttplug.Server.Test

--- a/Buttplug.Server.Test/Bluetooth/Devices/GeneralDeviceTests.cs
+++ b/Buttplug.Server.Test/Bluetooth/Devices/GeneralDeviceTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using Buttplug.Server.Bluetooth;
 using Buttplug.Server.Test.Util;

--- a/Buttplug.Server.Test/ButtplugBluetoothDeviceTests.cs
+++ b/Buttplug.Server.Test/ButtplugBluetoothDeviceTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Linq;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Server.Bluetooth;
 using NUnit.Framework;
 

--- a/Buttplug.Server.Test/ButtplugServerMessageTests.cs
+++ b/Buttplug.Server.Test/ButtplugServerMessageTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using NUnit.Framework;
 

--- a/Buttplug.Server.Test/ButtplugServerTests.cs
+++ b/Buttplug.Server.Test/ButtplugServerTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using Buttplug.Core.Test;
 using NUnit.Framework;

--- a/Buttplug.Server.Test/TestBluetoothSubtypeManager.cs
+++ b/Buttplug.Server.Test/TestBluetoothSubtypeManager.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Server.Bluetooth;
 
 namespace Buttplug.Server.Test

--- a/Buttplug.Server.Test/TestDeviceSubtypeManager.cs
+++ b/Buttplug.Server.Test/TestDeviceSubtypeManager.cs
@@ -5,6 +5,7 @@
 // </copyright>
 
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Test;
 using JetBrains.Annotations;
 

--- a/Buttplug.Server.Test/Util/BluetoothDeviceTestUtils.cs
+++ b/Buttplug.Server.Test/Util/BluetoothDeviceTestUtils.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using Buttplug.Server.Bluetooth;
 using JetBrains.Annotations;

--- a/Buttplug.Server/Bluetooth/BluetoothSubtypeManager.cs
+++ b/Buttplug.Server/Bluetooth/BluetoothSubtypeManager.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Server.Bluetooth.Devices;
 using JetBrains.Annotations;
 

--- a/Buttplug.Server/Bluetooth/ButtplugBluetoothDevice.cs
+++ b/Buttplug.Server/Bluetooth/ButtplugBluetoothDevice.cs
@@ -6,6 +6,8 @@
 
 using System;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using JetBrains.Annotations;
 
 namespace Buttplug.Server.Bluetooth

--- a/Buttplug.Server/Bluetooth/Devices/FleshlightLaunch.cs
+++ b/Buttplug.Server/Bluetooth/Devices/FleshlightLaunch.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using Buttplug.Server.Util;
 using JetBrains.Annotations;

--- a/Buttplug.Server/Bluetooth/Devices/Kiiroo.cs
+++ b/Buttplug.Server/Bluetooth/Devices/Kiiroo.cs
@@ -10,6 +10,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using Buttplug.Server.Util;
 using JetBrains.Annotations;

--- a/Buttplug.Server/Bluetooth/Devices/KiirooGen2Vibe.cs
+++ b/Buttplug.Server/Bluetooth/Devices/KiirooGen2Vibe.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 

--- a/Buttplug.Server/Bluetooth/Devices/LiBo.cs
+++ b/Buttplug.Server/Bluetooth/Devices/LiBo.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 
 namespace Buttplug.Server.Bluetooth.Devices

--- a/Buttplug.Server/Bluetooth/Devices/Lovense.cs
+++ b/Buttplug.Server/Bluetooth/Devices/Lovense.cs
@@ -10,6 +10,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 
 namespace Buttplug.Server.Bluetooth.Devices

--- a/Buttplug.Server/Bluetooth/Devices/MagicMotion.cs
+++ b/Buttplug.Server/Bluetooth/Devices/MagicMotion.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 
 namespace Buttplug.Server.Bluetooth.Devices

--- a/Buttplug.Server/Bluetooth/Devices/MysteryVibe.cs
+++ b/Buttplug.Server/Bluetooth/Devices/MysteryVibe.cs
@@ -11,6 +11,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 
 namespace Buttplug.Server.Bluetooth.Devices

--- a/Buttplug.Server/Bluetooth/Devices/Vibratissimo.cs
+++ b/Buttplug.Server/Bluetooth/Devices/Vibratissimo.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 
 namespace Buttplug.Server.Bluetooth.Devices

--- a/Buttplug.Server/Bluetooth/Devices/VorzeSA.cs
+++ b/Buttplug.Server/Bluetooth/Devices/VorzeSA.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 
 namespace Buttplug.Server.Bluetooth.Devices

--- a/Buttplug.Server/Bluetooth/Devices/WeVibe.cs
+++ b/Buttplug.Server/Bluetooth/Devices/WeVibe.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 
 namespace Buttplug.Server.Bluetooth.Devices

--- a/Buttplug.Server/Bluetooth/Devices/Youcups.cs
+++ b/Buttplug.Server/Bluetooth/Devices/Youcups.cs
@@ -10,6 +10,8 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 
 namespace Buttplug.Server.Bluetooth.Devices

--- a/Buttplug.Server/Bluetooth/IBluetoothDeviceInfo.cs
+++ b/Buttplug.Server/Bluetooth/IBluetoothDeviceInfo.cs
@@ -7,6 +7,8 @@
 using System;
 using System.Collections.Generic;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using JetBrains.Annotations;
 
 namespace Buttplug.Server.Bluetooth

--- a/Buttplug.Server/Bluetooth/IBluetoothDeviceInterface.cs
+++ b/Buttplug.Server/Bluetooth/IBluetoothDeviceInterface.cs
@@ -8,6 +8,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Messages;
 
 namespace Buttplug.Server.Bluetooth
 {

--- a/Buttplug.Server/ButtplugServer.cs
+++ b/Buttplug.Server/ButtplugServer.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 

--- a/Buttplug.Server/DeviceAddedEventArgs.cs
+++ b/Buttplug.Server/DeviceAddedEventArgs.cs
@@ -6,6 +6,7 @@
 
 using System;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
 
 namespace Buttplug.Server
 {

--- a/Buttplug.Server/DeviceManager.cs
+++ b/Buttplug.Server/DeviceManager.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core;
+using Buttplug.Core.Devices;
+using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
 using JetBrains.Annotations;
 

--- a/Buttplug.Server/DeviceSubtypeManager.cs
+++ b/Buttplug.Server/DeviceSubtypeManager.cs
@@ -6,6 +6,7 @@
 
 using System;
 using Buttplug.Core;
+using Buttplug.Core.Logging;
 using JetBrains.Annotations;
 
 namespace Buttplug.Server


### PR DESCRIPTION
Some of the Core classes have moved from Buttplug.Core to directories
under that path. The convention is that the namespace reflests the path,
so this change moves the namespaces of those moved classes and updates
the references to them.