### PR TITLE
build: Only let appveyor search for git tags on master

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,9 @@ install:
           $env:newVersion="$env:APPVEYOR_REPO_TAG_NAME.$env:APPVEYOR_BUILD_NUMBER"
           $env:appveyor_info_version="$env:APPVEYOR_REPO_TAG_NAME"
         } Else {
-          $gitVersion=git describe --tags --abbrev=0 $env:APPVEYOR_REPO_BRANCH
+          # We'll only tag on master for this repo, so just assume
+          # we'll find the last tag based on whatever head we're on.
+          $gitVersion=git describe --tags --abbrev=0 HEAD
           $env:newVersion="$gitVersion.$env:APPVEYOR_BUILD_NUMBER"
           $env:appveyor_info_version="$env:newVersion-$env:APPVEYOR_REPO_BRANCH"
         }      

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -177,8 +177,3 @@ deploy:
       configuration: release
       appveyor_repo_provider: github
       appveyor_repo_name: buttplugio/buttplug-csharp
-notifications:
-  - provider: Slack
-    auth_token:
-      secure: niT02PuMtJmQsNxJo6dfdlU6X3gBzyPsFsskTSGHFDgkRL2IRj6iBzjTGhF1mM9x
-    channel: '#buttplug'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -144,9 +144,11 @@ after_test:
 # Discord webhook
 on_success:
   - ps: Invoke-RestMethod https://raw.githubusercontent.com/DiscordHooks/appveyor-discord-webhook/master/send.ps1 -o send.ps1
+  - ps: write-host "Sending success message to discord webhook"
   - ps: ./send.ps1 success $env:DISCORD_WEBHOOK_URL
 on_failure:
   - ps: Invoke-RestMethod https://raw.githubusercontent.com/DiscordHooks/appveyor-discord-webhook/master/send.ps1 -o send.ps1
+  - ps: write-host "Sending failure message to discord webhook"
   - ps: ./send.ps1 failure $env:DISCORD_WEBHOOK_URL
     
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,8 @@ environment:
     secure: SvHymEaf8z/NGLTrYUeI3PutAKTLiWlQtT0LVuVTkPGSG1uWXsF22ySBx4o/sRH1
   git_email: build@appveyor.com
   git_user: Appveyor Build
+  DISCORD_WEBHOOK_URL:
+    secure: 0N/+OHOE9ePrZMtAS0kfQfqrM+zqQgYqpR5N9GHmEbipmWshAzRcTkfA1inZGNE8aijVzDT78LVZrwFZbhaU4YEd9rfuTbgD600v6GnunBroFmTfeFXlLHDvB7WzFwU6ZqibKN7I6rD/tgt675wK77mDtDdAetqTrinwLdINTn8=
   
 # Taken from https://boblokerse.github.io/2015/11/03/GitVersion-versioning-made-easy-and-dry/
 install:
@@ -138,7 +140,15 @@ after_test:
 # Enable for RDP connections to failing build VMs
 # on_finish:
 #   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-      
+
+# Discord webhook
+on_success:
+  - ps: Invoke-RestMethod https://raw.githubusercontent.com/DiscordHooks/appveyor-discord-webhook/master/send.ps1 -o send.ps1
+  - ps: ./send.ps1 success $env:DISCORD_WEBHOOK_URL
+on_failure:
+  - ps: Invoke-RestMethod https://raw.githubusercontent.com/DiscordHooks/appveyor-discord-webhook/master/send.ps1 -o send.ps1
+  - ps: ./send.ps1 failure $env:DISCORD_WEBHOOK_URL
+    
 cache:
   - packages -> **\packages.config
   # Cache chocolatey packages


### PR DESCRIPTION
Due to the inclusion of the dev branch, plus the way appveyor checks
things out, things can get confused when a PR comes in for the dev
branch. Make sure we only look for tags on master.

Fixes #552