### PR TITLE
fix: Fixing a couple of issues that blocked device reconnection

### DIFF
--- a/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceInterface.cs
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothDeviceInterface.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Threading;
 using System.Threading.Tasks;
@@ -132,7 +133,7 @@ namespace Buttplug.Server.Managers.UWPBluetoothManager
                 }
             }
 
-            if (_indexedChars == null)
+            if (_indexedChars == null || !_indexedChars.Any())
             {
                 throw new ButtplugDeviceException(BpLogger, $"No characteristics to connect to for device {Name}");
             }

--- a/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothManager.cs
+++ b/Buttplug.Server.Managers.UWPBluetoothManager/UWPBluetoothManager.cs
@@ -115,15 +115,15 @@ namespace Buttplug.Server.Managers.UWPBluetoothManager
                 return;
             }
 
-            BpLogger.Trace("BLE device found: " + advertName);
-
             // We always need a name to match against.
             if (advertName == string.Empty)
             {
+                // Don't add no-named devices to the seen list, because WeVibes take a few laps to get the name
                 return;
             }
 
             // If we've got an actual name this time around, add to our seen list.
+            BpLogger.Trace("BLE device found: " + advertName);
             _seenAddresses.Add(btAddr);
 
             // todo Add advertGUIDs back in. Not sure that ever really gets used though.
@@ -151,6 +151,8 @@ namespace Buttplug.Server.Managers.UWPBluetoothManager
             // remove it from seen devices, since the user may turn it back on during this scanning period.
             if (fromBluetoothAddressAsync == null)
             {
+                // Remove the address from our "seen" list so that we try to reconnect again.
+                _seenAddresses.Remove(btAddr);
                 return;
             }
 
@@ -169,10 +171,10 @@ namespace Buttplug.Server.Managers.UWPBluetoothManager
             {
                 BpLogger.Error(
                     $"Cannot connect to device {advertName} {btAddr}: {ex.Message}");
-                // Remove the address from our "seen" list so that we try to reconnect again.
-                _seenAddresses.Remove(btAddr);
-                return;
             }
+
+            // Remove the address from our "seen" list so that we try to reconnect again.
+            _seenAddresses.Remove(btAddr);
         }
 
         private void OnWatcherStopped(BluetoothLEAdvertisementWatcher aObj,

--- a/Buttplug/Devices/ButtplugDevice.cs
+++ b/Buttplug/Devices/ButtplugDevice.cs
@@ -31,7 +31,7 @@ namespace Buttplug.Devices
         public uint Index { get; set; }
 
         /// <inheritdoc />
-        public bool Connected => _device.Connected;
+        public bool Connected => !_isDisconnected;
 
         /// <inheritdoc />
         [CanBeNull]


### PR DESCRIPTION
In the Bluetooth Manager, devices that connected were added to the seen list, so on reconnection were ignored unless the scanning was toggled on and off again.

In the ButtplugDevice code, we were defereeing to the inner device object for a connection status, but I was seeing the same device object being reused after power cyclying the device, which caused the device manager to error with duplicate device before telling the client that the device was back.