### PR TITLE
feat: Adding protocol support for WeVibe Vector

### DIFF
--- a/Buttplug/Devices/Protocols/WeVibeProtocol.cs
+++ b/Buttplug/Devices/Protocols/WeVibeProtocol.cs
@@ -5,6 +5,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,9 +27,25 @@ namespace Buttplug.Devices.Protocols
             "Nova",
             "NOVAV2",
             "Sync",
+            "Vector",
+        };
+
+        private static readonly Dictionary<string, string> NameMap = new Dictionary<string, string>()
+        {
+            { "Cougar", "4 Plus" },
+            { "4plus", "4 Plus" },
+            { "classic", "Classic" },
+            { "NOVAV2", "Nova" },
+        };
+
+        private static readonly string[] EightBitSpeed =
+        {
+            "Moxie",
+            "Vector",
         };
 
         private readonly uint _vibratorCount = 1;
+        private readonly bool _eightBitSpeed = false;
         private readonly double[] _vibratorSpeed = { 0, 0 };
 
         public WeVibeProtocol(IButtplugLogManager aLogManager,
@@ -40,6 +57,16 @@ namespace Buttplug.Devices.Protocols
             if (DualVibes.Contains(aInterface.Name))
             {
                 _vibratorCount = 2;
+            }
+
+            if (NameMap.ContainsKey(aInterface.Name))
+            {
+                Name = $"WeVibe {NameMap[aInterface.Name]}";
+            }
+
+            if (EightBitSpeed.Contains(aInterface.Name))
+            {
+                _eightBitSpeed = true;
             }
 
             AddMessageHandler<SingleMotorVibrateCmd>(HandleSingleMotorVibrateCmd);
@@ -82,18 +109,36 @@ namespace Buttplug.Devices.Protocols
 
             SentVibration = true;
 
-            var rSpeedInt = Convert.ToUInt16(_vibratorSpeed[0] * 15);
-            var rSpeedExt = Convert.ToUInt16(_vibratorSpeed[_vibratorCount - 1] * 15);
-
             // 0f 03 00 bc 00 00 00 00
             var data = new byte[] { 0x0f, 0x03, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00 };
-            data[3] = Convert.ToByte(rSpeedExt); // External
-            data[3] |= Convert.ToByte(rSpeedInt << 4); // Internal
+            var rSpeedInt = 0;
+            var rSpeedExt = 0;
+
+            if (_eightBitSpeed)
+            {
+                rSpeedInt = Convert.ToUInt16(_vibratorSpeed[0] * 12);
+                rSpeedExt = Convert.ToUInt16(_vibratorSpeed[_vibratorCount - 1] * 12);
+
+                data[3] = Convert.ToByte(rSpeedExt + 3); // External
+                data[4] = Convert.ToByte(rSpeedInt + 3); // Internal
+                data[5] = Convert.ToByte(rSpeedInt == 0 ? 0 : 1);
+                data[5] |= Convert.ToByte(rSpeedExt == 0 ? 0 : 2);
+            }
+            else
+            {
+                rSpeedInt = Convert.ToUInt16(_vibratorSpeed[0] * 15);
+                rSpeedExt = Convert.ToUInt16(_vibratorSpeed[_vibratorCount - 1] * 15);
+
+                data[3] = Convert.ToByte(rSpeedExt); // External
+                data[3] |= Convert.ToByte(rSpeedInt << 4); // Internal
+            }
 
             // ReSharper disable once InvertIf
             if (rSpeedInt == 0 && rSpeedExt == 0)
             {
                 data[1] = 0x00;
+                data[3] = 0x00;
+                data[4] = 0x00;
                 data[5] = 0x00;
             }
 


### PR DESCRIPTION
This should also work for the Moxie; however, these
new devices seem to require pairing before they'll
respond. I haven't worked out that magic yet though,
but once paired the device does not required the
pairing to be retained (the adapter address must be
stored on the device).

To get the Vector into pairing mode, hold down the
power button for 5 seconds (it'll buzz, but don't release)
then hit pair in Bluetooth LE explorer app.

I'll investigate the pairing logic in that app at some
point soon.