### PR TITLE
feat: Expanding the device configs

### DIFF
--- a/Buttplug.Test/Devices/Protocols/AnerosViviTests.cs
+++ b/Buttplug.Test/Devices/Protocols/AnerosViviTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<AnerosProtocol>("Massage Demo");
+            await testUtil.SetupTest<AnerosProtocol>("Massage Demo", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/CuemeTests.cs
+++ b/Buttplug.Test/Devices/Protocols/CuemeTests.cs
@@ -9,9 +9,11 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -28,7 +30,12 @@ namespace Buttplug.Test.Devices.Protocols
         [SetUp]
         public async Task Init()
         {
-            await _testUtil.SetupTest<CuemeProtocol>("FUNCODE_");
+            DeviceConfigurationManager.LoadBaseConfigurationFromResource();
+            var mgr = DeviceConfigurationManager.Manager;
+            var pconfigs = mgr.GetProtocolConfig("cueme");
+            var configs = pconfigs.First().DeviceConfigs;
+
+            await _testUtil.SetupTest<CuemeProtocol>("FUNCODE_ABABABABAB_3", configs);
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/FleshlightLaunchTests.cs
+++ b/Buttplug.Test/Devices/Protocols/FleshlightLaunchTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<KiirooGen2Protocol>("Launch");
+            await testUtil.SetupTest<KiirooGen2Protocol>("Launch", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/KiirooGen21VibeTests.cs
+++ b/Buttplug.Test/Devices/Protocols/KiirooGen21VibeTests.cs
@@ -13,6 +13,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using FluentAssertions;
@@ -37,7 +38,7 @@ namespace Buttplug.Test.Devices.Protocols
                 }
 
                 var testUtil = new ProtocolTestUtils();
-                await testUtil.SetupTest<KiirooGen21Protocol>(item.Key);
+                await testUtil.SetupTest<KiirooGen21Protocol>(item.Key, new List<DeviceConfiguration>());
                 var expected = new Dictionary<Type, uint>()
                 {
                     { typeof(StopDeviceCmd), 0 },
@@ -68,7 +69,7 @@ namespace Buttplug.Test.Devices.Protocols
                 }
 
                 var testUtil = new ProtocolTestUtils();
-                await testUtil.SetupTest<KiirooGen21Protocol>(item.Key);
+                await testUtil.SetupTest<KiirooGen21Protocol>(item.Key, new List<DeviceConfiguration>());
                 var expected = new byte[] { 1, 0 };
                 for (var i = 0u; i < item.Value.VibeCount; ++i)
                 {
@@ -95,7 +96,7 @@ namespace Buttplug.Test.Devices.Protocols
                 }
 
                 var testUtil = new ProtocolTestUtils();
-                await testUtil.SetupTest<KiirooGen21Protocol>(item.Key);
+                await testUtil.SetupTest<KiirooGen21Protocol>(item.Key, new List<DeviceConfiguration>());
                 var speeds = new[] { 0.25, 0.5, 0.75 };
                 var features = new List<VibrateCmd.VibrateSubcommand>();
                 for (var i = 0u; i < item.Value.VibeCount; ++i)
@@ -129,7 +130,7 @@ namespace Buttplug.Test.Devices.Protocols
                 }
 
                 var testUtil = new ProtocolTestUtils();
-                await testUtil.SetupTest<KiirooGen21Protocol>(item.Key);
+                await testUtil.SetupTest<KiirooGen21Protocol>(item.Key, new List<DeviceConfiguration>());
                 testUtil.TestInvalidVibrateCmd(item.Value.VibeCount);
             }
         }

--- a/Buttplug.Test/Devices/Protocols/KiirooGen2VibeTests.cs
+++ b/Buttplug.Test/Devices/Protocols/KiirooGen2VibeTests.cs
@@ -13,6 +13,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using FluentAssertions;
@@ -32,7 +33,7 @@ namespace Buttplug.Test.Devices.Protocols
             foreach (var item in KiirooGen2VibeProtocol.DevInfos)
             {
                 var testUtil = new ProtocolTestUtils();
-                await testUtil.SetupTest<KiirooGen2VibeProtocol>(item.Key);
+                await testUtil.SetupTest<KiirooGen2VibeProtocol>(item.Key, new List<DeviceConfiguration>());
                 testUtil.TestDeviceAllowedMessages(new Dictionary<Type, uint>()
                 {
                     { typeof(StopDeviceCmd), 0 },
@@ -50,7 +51,7 @@ namespace Buttplug.Test.Devices.Protocols
             foreach (var item in KiirooGen2VibeProtocol.DevInfos)
             {
                 var testUtil = new ProtocolTestUtils();
-                await testUtil.SetupTest<KiirooGen2VibeProtocol>(item.Key);
+                await testUtil.SetupTest<KiirooGen2VibeProtocol>(item.Key, new List<DeviceConfiguration>());
                 var expected = new byte[] { 0, 0, 0 };
                 for (var i = 0u; i < item.Value.VibeCount; ++i)
                 {
@@ -72,7 +73,7 @@ namespace Buttplug.Test.Devices.Protocols
             foreach (var item in KiirooGen2VibeProtocol.DevInfos)
             {
                 var testUtil = new ProtocolTestUtils();
-                await testUtil.SetupTest<KiirooGen2VibeProtocol>(item.Key);
+                await testUtil.SetupTest<KiirooGen2VibeProtocol>(item.Key, new List<DeviceConfiguration>());
                 var speeds = new[] { 0.25, 0.5, 0.75 };
                 var features = new List<VibrateCmd.VibrateSubcommand>();
                 for (var i = 0u; i < item.Value.VibeCount; ++i)
@@ -101,7 +102,7 @@ namespace Buttplug.Test.Devices.Protocols
             foreach (var item in KiirooGen2VibeProtocol.DevInfos)
             {
                 var testUtil = new ProtocolTestUtils();
-                await testUtil.SetupTest<KiirooGen2VibeProtocol>(item.Key);
+                await testUtil.SetupTest<KiirooGen2VibeProtocol>(item.Key, new List<DeviceConfiguration>());
                 testUtil.TestInvalidVibrateCmd(item.Value.VibeCount);
             }
         }

--- a/Buttplug.Test/Devices/Protocols/KiirooOnyx1Tests.cs
+++ b/Buttplug.Test/Devices/Protocols/KiirooOnyx1Tests.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -31,7 +32,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<KiirooGen1Protocol>("ONYX");
+            await testUtil.SetupTest<KiirooGen1Protocol>("ONYX", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/KiirooOnyx2Tests.cs
+++ b/Buttplug.Test/Devices/Protocols/KiirooOnyx2Tests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<KiirooGen2Protocol>("Onyx2");
+            await testUtil.SetupTest<KiirooGen2Protocol>("Onyx2", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/KiirooTests.cs
+++ b/Buttplug.Test/Devices/Protocols/KiirooTests.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -31,7 +32,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<KiirooGen1Protocol>("PEARL");
+            await testUtil.SetupTest<KiirooGen1Protocol>("PEARL", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/LeloF1sTests.cs
+++ b/Buttplug.Test/Devices/Protocols/LeloF1sTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<LeloF1sProtocol>("F1s");
+            await testUtil.SetupTest<LeloF1sProtocol>("F1s", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/LiBoElleTests.cs
+++ b/Buttplug.Test/Devices/Protocols/LiBoElleTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -29,7 +30,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<LiBoProtocol>("PiPiJing");
+            await testUtil.SetupTest<LiBoProtocol>("PiPiJing", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/LiBoLaLaTests.cs
+++ b/Buttplug.Test/Devices/Protocols/LiBoLaLaTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -29,7 +30,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<LiBoProtocol>("BaiHu");
+            await testUtil.SetupTest<LiBoProtocol>("BaiHu", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/LiBoLuLuTests.cs
+++ b/Buttplug.Test/Devices/Protocols/LiBoLuLuTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -29,7 +30,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<LiBoProtocol>("LuXiaoHan");
+            await testUtil.SetupTest<LiBoProtocol>("LuXiaoHan", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/LovehoneyDesireKnickerVibeTests.cs
+++ b/Buttplug.Test/Devices/Protocols/LovehoneyDesireKnickerVibeTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<LovehoneyDesireProtocol>("KNICKER VIBE");
+            await testUtil.SetupTest<LovehoneyDesireProtocol>("KNICKER VIBE", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/LovehoneyDesireProstateVibeTests.cs
+++ b/Buttplug.Test/Devices/Protocols/LovehoneyDesireProstateVibeTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<LovehoneyDesireProtocol>("PROSTATE VIBE");
+            await testUtil.SetupTest<LovehoneyDesireProtocol>("PROSTATE VIBE", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/LovenseTests.cs
+++ b/Buttplug.Test/Devices/Protocols/LovenseTests.cs
@@ -8,10 +8,12 @@
 // ReSharper disable ConsiderUsingConfigureAwait
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,8 +32,13 @@ namespace Buttplug.Test.Devices.Protocols
         {
             testUtil = new ProtocolTestUtils();
 
+            DeviceConfigurationManager.LoadBaseConfigurationFromResource();
+            var mgr = DeviceConfigurationManager.Manager;
+            var pconfigs = mgr.GetProtocolConfig("lovense");
+            var configs = pconfigs.First().DeviceConfigs;
+
             // Just leave name the same as the prefix, we'll set device type via initialize.
-            await testUtil.SetupTest<LovenseProtocol>("LVS", false);
+            await testUtil.SetupTest<LovenseProtocol>("LVS", configs, false);
             testUtil.AddExpectedNotify("DeviceType;", Encoding.ASCII.GetBytes("W:39:000000000000"));
             await testUtil.Initialize();
         }
@@ -39,7 +46,7 @@ namespace Buttplug.Test.Devices.Protocols
         [Test]
         public void TestDeviceName()
         {
-            testUtil.TestDeviceName("Lovense Domi v39");
+            testUtil.TestDeviceName("Lovense Domi");
         }
 
         [Test]
@@ -117,8 +124,13 @@ namespace Buttplug.Test.Devices.Protocols
         {
             testUtil = new ProtocolTestUtils();
 
+            DeviceConfigurationManager.LoadBaseConfigurationFromResource();
+            var mgr = DeviceConfigurationManager.Manager;
+            var pconfigs = mgr.GetProtocolConfig("lovense");
+            var configs = pconfigs.First().DeviceConfigs;
+
             // Just leave name the same as the prefix, we'll set device type via initialize.
-            await testUtil.SetupTest<LovenseProtocol>("LVS", false);
+            await testUtil.SetupTest<LovenseProtocol>("LVS", configs, false);
             testUtil.AddExpectedNotify("DeviceType;", Encoding.ASCII.GetBytes("P:39:000000000000"));
             await testUtil.Initialize();
         }
@@ -126,7 +138,7 @@ namespace Buttplug.Test.Devices.Protocols
         [Test]
         public void TestDeviceName()
         {
-            testUtil.TestDeviceName("Lovense Edge v39");
+            testUtil.TestDeviceName("Lovense Edge");
         }
 
         [Test]
@@ -208,8 +220,13 @@ namespace Buttplug.Test.Devices.Protocols
         {
             testUtil = new ProtocolTestUtils();
 
+            DeviceConfigurationManager.LoadBaseConfigurationFromResource();
+            var mgr = DeviceConfigurationManager.Manager;
+            var pconfigs = mgr.GetProtocolConfig("lovense");
+            var configs = pconfigs.First().DeviceConfigs;
+
             // Just leave name the same as the prefix, we'll set device type via initialize.
-            await testUtil.SetupTest<LovenseProtocol>("LVS", false);
+            await testUtil.SetupTest<LovenseProtocol>("LVS", configs, false);
             testUtil.AddExpectedNotify("DeviceType;", Encoding.ASCII.GetBytes("A:13:000000000000"));
             await testUtil.Initialize();
         }
@@ -217,7 +234,7 @@ namespace Buttplug.Test.Devices.Protocols
         [Test]
         public void TestDeviceName()
         {
-            testUtil.TestDeviceName("Lovense Nora v13");
+            testUtil.TestDeviceName("Lovense Nora");
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/MagicMotionTests.cs
+++ b/Buttplug.Test/Devices/Protocols/MagicMotionTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<MagicMotionProtocol>("Smart Mini Vibe");
+            await testUtil.SetupTest<MagicMotionProtocol>("Smart Mini Vibe", new List<DeviceConfiguration>());
         }
 
         [Test]
@@ -108,7 +109,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<MagicMotionProtocol>("Eidolon");
+            await testUtil.SetupTest<MagicMotionProtocol>("Eidolon", new List<DeviceConfiguration>());
         }
 
         [Test]
@@ -187,7 +188,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<MagicMotionProtocol>("Krush");
+            await testUtil.SetupTest<MagicMotionProtocol>("Krush", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/MotorbunnyTests.cs
+++ b/Buttplug.Test/Devices/Protocols/MotorbunnyTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -23,7 +24,7 @@ namespace Buttplug.Test.Devices.Protocols
             testUtil = new ProtocolTestUtils();
 
             // Just leave name the same as the prefix, we'll set device type via initialize.
-            await testUtil.SetupTest<MotorbunnyProtocol>("MB Controller", false);
+            await testUtil.SetupTest<MotorbunnyProtocol>("MB Controller", new List<DeviceConfiguration>(), false);
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/MysteryVibeTests.cs
+++ b/Buttplug.Test/Devices/Protocols/MysteryVibeTests.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -31,7 +32,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<MysteryVibeProtocol>("MV Crescendo");
+            await testUtil.SetupTest<MysteryVibeProtocol>("MV Crescendo", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/PicobongTests.cs
+++ b/Buttplug.Test/Devices/Protocols/PicobongTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<PicobongProtocol>("Diver");
+            await testUtil.SetupTest<PicobongProtocol>("Diver", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/PrettyLoveTests.cs
+++ b/Buttplug.Test/Devices/Protocols/PrettyLoveTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<PrettyLoveProtocol>("Aogu BLE Device");
+            await testUtil.SetupTest<PrettyLoveProtocol>("Aogu BLE Device", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/RealovTests.cs
+++ b/Buttplug.Test/Devices/Protocols/RealovTests.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -31,7 +32,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<RealovProtocol>("REALOV_VIBE");
+            await testUtil.SetupTest<RealovProtocol>("REALOV_VIBE", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/SvakomTests.cs
+++ b/Buttplug.Test/Devices/Protocols/SvakomTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<SvakomProtocol>("Aogu SCB");
+            await testUtil.SetupTest<SvakomProtocol>("Aogu SCB", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/Utils/ProtocolTestUtils.cs
+++ b/Buttplug.Test/Devices/Protocols/Utils/ProtocolTestUtils.cs
@@ -26,7 +26,7 @@ namespace Buttplug.Test.Devices.Protocols.Utils
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "Test classes can skip documentation requirements")]
     public interface IProtocolTestUtils
     {
-        Task SetupTest<T>(string aDeviceName, bool aShouldInitialize = false) where T : IButtplugDeviceProtocol;
+        Task SetupTest<T>(string aDeviceName, List<DeviceConfiguration> aConfigs, bool aShouldInitialize = false) where T : IButtplugDeviceProtocol;
 
         Task TestDeviceMessageNoop(ButtplugDeviceMessage aOutgoingMessage);
     }
@@ -36,13 +36,15 @@ namespace Buttplug.Test.Devices.Protocols.Utils
     {
         private TestDeviceImpl _testImpl;
         private IButtplugDevice _testDevice;
+        private List<DeviceConfiguration> _configs;
 
-        public async Task SetupTest<T>(string aDeviceName, bool aShouldInitialize = true)
+        public async Task SetupTest<T>(string aDeviceName, List<DeviceConfiguration> aConfigs, bool aShouldInitialize = true)
         where T : IButtplugDeviceProtocol
         {
             var logMgr = new ButtplugLogManager();
             _testImpl = new TestDeviceImpl(logMgr, aDeviceName);
             _testDevice = new ButtplugDevice(logMgr, typeof(T), _testImpl);
+            _configs = aConfigs;
 
             if (!aShouldInitialize)
             {
@@ -54,7 +56,7 @@ namespace Buttplug.Test.Devices.Protocols.Utils
 
         public async Task Initialize()
         {
-            await _testDevice.InitializeAsync(new List<DeviceConfiguration>());
+            await _testDevice.InitializeAsync(_configs);
             _testImpl.LastWritten.Clear();
         }
 

--- a/Buttplug.Test/Devices/Protocols/VibratissimoTests.cs
+++ b/Buttplug.Test/Devices/Protocols/VibratissimoTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<VibratissimoProtocol>("Vibratissimo");
+            await testUtil.SetupTest<VibratissimoProtocol>("Vibratissimo", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/VorzeSATests.cs
+++ b/Buttplug.Test/Devices/Protocols/VorzeSATests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -28,7 +29,7 @@ namespace Buttplug.Test.Devices.Protocols
         internal async Task TestAllowedMessages(string aDeviceName, VorzeSAProtocol.CommandType aCommandType)
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName);
+            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName, new List<DeviceConfiguration>());
 
             if (aCommandType == VorzeSAProtocol.CommandType.Rotate)
             {
@@ -59,7 +60,7 @@ namespace Buttplug.Test.Devices.Protocols
         internal async Task TestStopDeviceCmd(string aDeviceName, byte aPrefix, VorzeSAProtocol.CommandType aCommandType)
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName);
+            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName, new List<DeviceConfiguration>());
             var expected = new byte[] { aPrefix, (byte)aCommandType, 50 };
 
             if (aCommandType == VorzeSAProtocol.CommandType.Rotate)
@@ -95,7 +96,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task TestVorzeA10CycloneCmd(string aDeviceName, byte aPrefix)
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName);
+            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName, new List<DeviceConfiguration>());
             var expected = new byte[] { aPrefix, 0x1, 50 };
 
             await testUtil.TestDeviceMessage(new VorzeA10CycloneCmd(4, 50, false),
@@ -116,7 +117,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task TestRotateCmd(string aDeviceName, byte aPrefix)
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName);
+            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName, new List<DeviceConfiguration>());
             var expected = new byte[] { aPrefix, 0x1, 50 };
 
             await testUtil.TestDeviceMessage(
@@ -139,7 +140,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task TestSingleMotorVibrateCmd(string aDeviceName, byte aPrefix)
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName);
+            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName, new List<DeviceConfiguration>());
             var expected = new byte[] { aPrefix, 0x03, 50 };
 
             await testUtil.TestDeviceMessage(new SingleMotorVibrateCmd(4, 0.5),
@@ -160,7 +161,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task TestVibrateCmd(string aDeviceName, byte aPrefix)
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName);
+            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName, new List<DeviceConfiguration>());
             var expected = new byte[] { aPrefix, 0x3, 50 };
 
             await testUtil.TestDeviceMessage(
@@ -183,7 +184,7 @@ namespace Buttplug.Test.Devices.Protocols
         internal async Task TestInvalidCmds(string aDeviceName, VorzeSAProtocol.CommandType aCommandType)
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName);
+            await testUtil.SetupTest<VorzeSAProtocol>(aDeviceName, new List<DeviceConfiguration>());
             if (aCommandType == VorzeSAProtocol.CommandType.Rotate)
             {
                 testUtil.TestInvalidDeviceMessage(RotateCmd.Create(4, 1, 0.5, false, 0));

--- a/Buttplug.Test/Devices/Protocols/WeVibeTests.cs
+++ b/Buttplug.Test/Devices/Protocols/WeVibeTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -30,7 +31,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<WeVibeProtocol>("Ditto");
+            await testUtil.SetupTest<WeVibeProtocol>("Ditto", new List<DeviceConfiguration>());
         }
 
         [Test]
@@ -108,7 +109,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<WeVibeProtocol>("4plus");
+            await testUtil.SetupTest<WeVibeProtocol>("4plus", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug.Test/Devices/Protocols/YoucupsTests.cs
+++ b/Buttplug.Test/Devices/Protocols/YoucupsTests.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
 using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
 using Buttplug.Devices.Protocols;
 using Buttplug.Test.Devices.Protocols.Utils;
 using JetBrains.Annotations;
@@ -31,7 +32,7 @@ namespace Buttplug.Test.Devices.Protocols
         public async Task Init()
         {
             testUtil = new ProtocolTestUtils();
-            await testUtil.SetupTest<YoucupsProtocol>("Youcups");
+            await testUtil.SetupTest<YoucupsProtocol>("Youcups", new List<DeviceConfiguration>());
         }
 
         [Test]

--- a/Buttplug/Devices/ButtplugDevice.cs
+++ b/Buttplug/Devices/ButtplugDevice.cs
@@ -145,7 +145,7 @@ namespace Buttplug.Devices
                 ident.Add(aConfigurations.First());
             }
 
-            await _protocol.ConfigureAsync(ident.First(), aToken);
+            await _protocol.ConfigureAsync(ident.Any() ? ident.First() : null, aToken);
         }
 
         /// <inheritdoc />

--- a/Buttplug/Devices/ButtplugDevice.cs
+++ b/Buttplug/Devices/ButtplugDevice.cs
@@ -116,25 +116,36 @@ namespace Buttplug.Devices
         /// <inheritdoc />
         public virtual async Task InitializeAsync(List<DeviceConfiguration> aConfigurations, CancellationToken aToken)
         {
-            // Run initialize in order to set the DeviceConfigIdentifier, if needed.,
+            // Run initialize in order to set the DeviceConfigIdentifier, if needed.
             await _protocol.InitializeAsync(aToken);
+
             // Look up the identifier in the device configuration records
             var ident = (from config in aConfigurations
                 where config.Identifiers.Contains(_protocol.DeviceConfigIdentifier)
                 select config).ToList();
+
             // If all we have is one configuration, it may be the default. If
             // nothing else was found, select it. This will happen for cases
             // like XInput.
-            if (ident.Count() == 0 && aConfigurations.Count == 1)
+            if (!ident.Any() && aConfigurations.Count == 1)
             {
                 ident.Add(aConfigurations.First());
             }
 
-            if (ident.Count() > 0)
+            if (ident.Any())
             {
                 // This will usually be en-us for now, until we get more languages in.
                 Name = ident.First().Names.First().Value;
             }
+
+            // Grab the first config, assume it's just defaults for now
+            // todo: get a pure default config
+            if (!ident.Any() && aConfigurations.Any())
+            {
+                ident.Add(aConfigurations.First());
+            }
+
+            await _protocol.ConfigureAsync(ident.First(), aToken);
         }
 
         /// <inheritdoc />

--- a/Buttplug/Devices/ButtplugDeviceProtocol.cs
+++ b/Buttplug/Devices/ButtplugDeviceProtocol.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Buttplug.Core;
 using Buttplug.Core.Logging;
 using Buttplug.Core.Messages;
+using Buttplug.Devices.Configuration;
 using JetBrains.Annotations;
 
 namespace Buttplug.Devices
@@ -85,8 +86,22 @@ namespace Buttplug.Devices
             return await MsgFuncs[aMsg.GetType()].Function.Invoke(aMsg, aToken).ConfigureAwait(false);
         }
 
+        /// <inheritdoc />
         public virtual Task InitializeAsync(CancellationToken aToken)
         {
+            return Task.FromResult<ButtplugMessage>(new Ok(ButtplugConsts.SystemMsgId));
+        }
+
+        /// <inheritdoc />
+        public virtual Task ConfigureAsync(DeviceConfiguration aConfig, CancellationToken aToken)
+        {
+            // Default behaviour: make sure there's a StopDeviceCmd or errors will be thrown later
+            if (!MsgFuncs.ContainsKey(typeof(StopDeviceCmd)))
+            {
+                AddMessageHandler<StopDeviceCmd>((message, token) =>
+                    Task.FromResult<ButtplugMessage>(new Ok(message.Id)));
+            }
+
             return Task.FromResult<ButtplugMessage>(new Ok(ButtplugConsts.SystemMsgId));
         }
 

--- a/Buttplug/Devices/Configuration/DeviceConfigurationManager.cs
+++ b/Buttplug/Devices/Configuration/DeviceConfigurationManager.cs
@@ -98,7 +98,7 @@ namespace Buttplug.Devices.Configuration
                 List<DeviceConfiguration> conf;
                 DeviceConfiguration defaults;
 
-                conf = obj["configurations"].Value<JArray>().ToObject<List<DeviceConfiguration>>();
+                conf = obj["configurations"]?.Value<JArray>().ToObject<List<DeviceConfiguration>>() ?? new List<DeviceConfiguration>();
                 try
                 {
                     defaults = obj["defaults"].Value<JObject>().ToObject<DeviceConfiguration>();
@@ -204,6 +204,12 @@ namespace Buttplug.Devices.Configuration
 
             _protocolConfigs[aProtocolName].Add(aConfiguration);
         }
+
+        public List<IProtocolConfiguration> GetProtocolConfig(string aProtocolName)
+        {
+            return _protocolConfigs[aProtocolName];
+        }
+
 
         public void AddWhitelist(IProtocolConfiguration aConfiguration)
         {

--- a/Buttplug/Devices/Configuration/ProtocolConfiguration.cs
+++ b/Buttplug/Devices/Configuration/ProtocolConfiguration.cs
@@ -23,7 +23,10 @@ namespace Buttplug.Devices.Configuration
         public static IDictionary<TKey, TValue> Merge<TKey, TValue>(IDictionary<TKey, TValue> dictA, IDictionary<TKey, TValue> dictB)
             where TValue : class
         {
-            return dictA.Keys.Union(dictB.Keys).ToDictionary(k => k, k => dictA.ContainsKey(k) ? dictA[k] : dictB[k]);
+            return
+                dictA == null ? dictB :
+                dictB == null ? dictA :
+                dictA.Keys.Union(dictB.Keys).ToDictionary(k => k, k => dictA.ContainsKey(k) ? dictA[k] : dictB[k]);
         }
 
         public void AddDefaults(DeviceConfiguration aDefaults)

--- a/Buttplug/Devices/IButtplugDeviceProtocol.cs
+++ b/Buttplug/Devices/IButtplugDeviceProtocol.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Buttplug.Core.Messages;
+using Buttplug.Devices.Configuration;
 using JetBrains.Annotations;
 
 namespace Buttplug.Devices
@@ -42,6 +43,14 @@ namespace Buttplug.Devices
         /// <returns>Response, usually <see cref="Ok"/> or <see cref="Error"/>.</returns>
         [NotNull]
         Task InitializeAsync(CancellationToken aToken = default(CancellationToken));
+
+        /// <summary>
+        /// Configures a device. Required for devices that may share protocol definitions with
+        /// varying numbers of device features, etc.
+        /// </summary>
+        /// <returns>Response, usually <see cref="Ok"/> or <see cref="Error"/>.</returns>
+        [NotNull]
+        Task ConfigureAsync(DeviceConfiguration aConfig, CancellationToken aToken = default(CancellationToken));
 
         /// <summary>
         /// Retrieves the message attributes for the device associated with this message. Used for

--- a/dependencies/buttplug-device-config/buttplug-device-config-schema.json
+++ b/dependencies/buttplug-device-config/buttplug-device-config-schema.json
@@ -24,7 +24,7 @@
             "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$": {
               "type": "object",
               "patternProperties": {
-                "^(tx|rx|firmware|txmode|txvibrate|rxtouch|rxaccel|whitelist)$": {
+                "^(tx|rx|firmware|txmode|txvibrate|rxtouch|rxaccel|rxpressure|whitelist)$": {
                   "$ref": "#/components/uuid"
                 }
               },
@@ -99,6 +99,15 @@
       },
       "minItems": 1
     },
+    "FeatureOrder": {
+      "description": "Specifies the order features are exposed in by the ButtplugMessages.",
+      "type": "array",
+      "items": {
+        "minimum": 0,
+        "type": "integer"
+      },
+      "minItems": 2
+    },
     "NullMessageAttributes": {
       "description": "Attributes for device message that have no attributes.",
       "type": "object",
@@ -111,7 +120,8 @@
       "type": "object",
       "properties": {
         "FeatureCount": { "$ref": "#/components/FeatureCount" },
-        "StepCount": { "$ref": "#/components/StepCount" }
+        "StepCount": { "$ref": "#/components/StepCount" },
+        "FeatureOrder": { "$ref": "#/components/FeatureOrder" }
       },
       "additionalProperties": false,
       "minProperties": 0
@@ -217,7 +227,7 @@
     },
     "defaults-definition": {
       "type": "object",
-      "properties" : {
+      "properties": {
         "name": {
           "$ref": "#/components/name-field"
         },

--- a/dependencies/buttplug-device-config/buttplug-device-config.json
+++ b/dependencies/buttplug-device-config/buttplug-device-config.json
@@ -47,7 +47,7 @@
             "rx": "42300003-0023-4bd4-bbd5-a6920e4c5653"
           }
         }
-     },
+      },
       "defaults": {
         "messages": {
           "VibrateCmd": {
@@ -192,7 +192,7 @@
           "LinearCmd": {
             "FeatureCount": 1,
             "StepCount": [
-              100
+              99
             ]
           },
           "BatteryLevelCmd": {},
@@ -214,6 +214,1874 @@
           ],
           "name": {
             "en-us": "Kiiroo Onyx 2"
+          }
+        }
+      ]
+    },
+    "libo-elle": {
+      "btle": {
+        "names": [
+          "PiPiJing",
+          "Shuidi"
+        ],
+        "services": {
+          "00006000-0000-1000-8000-00805f9b34fb": {
+            "tx": "00006001-0000-1000-8000-00805f9b34fb",
+            "txmode": "00006002-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 2,
+            "StepCount": [
+              3,
+              14
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "PiPiJing"
+          ],
+          "name": {
+            "en-us": "LiBo Elle"
+          }
+        },
+        {
+          "identifier": [
+            "Shuidi"
+          ],
+          "name": {
+            "en-us": "Libo Elle 2"
+          }
+        }
+      ]
+    },
+    "libo-shark": {
+      "btle": {
+        "names": [
+          "ShaYu"
+        ],
+        "services": {
+          "00006000-0000-1000-8000-00805f9b34fb": {
+            "tx": "00006001-0000-1000-8000-00805f9b34fb",
+            "txmode": "00006002-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 2,
+            "StepCount": [
+              3,
+              3
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "ShaYu"
+          ],
+          "name": {
+            "en-us": "Libo Shark"
+          }
+        }
+      ]
+    },
+    "libo-karen": {
+      "btle": {
+        "names": [
+          "SuoYinQiu"
+        ],
+        "services": {
+          "00006000-0000-1000-8000-00805f9b34fb": {
+            "tx": "00006001-0000-1000-8000-00805f9b34fb",
+            "txmode": "00006002-0000-1000-8000-00805f9b34fb"
+          },
+          "00006050-0000-1000-8000-00805f9b34fb": {
+            "rxpressure": "00006051-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {}
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "SuoYinQiu"
+          ],
+          "name": {
+            "en-us": "Libo Karen"
+          }
+        }
+      ]
+    },
+    "libo-vibes": {
+      "btle": {
+        "names": [
+          "XiaoLu",
+          "LuXiaoHan",
+          "BaiHu",
+          "MonsterPub",
+          "Gugudai",
+          "Yuyi",
+          "LuWuShuang",
+          "LiBo",
+          "QingTing",
+          "Huohu"
+        ],
+        "services": {
+          "00006000-0000-1000-8000-00805f9b34fb": {
+            "tx": "00006001-0000-1000-8000-00805f9b34fb",
+            "txmode": "00006002-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              100
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "XiaoLu"
+          ],
+          "name": {
+            "en-us": "Libo Lottie"
+          }
+        },
+        {
+          "identifier": [
+            "MonsterPub"
+          ],
+          "name": {
+            "en-us": "Sistalk MonsterPub"
+          }
+        },
+        {
+          "identifier": [
+            "LuXiaoHan"
+          ],
+          "name": {
+            "en-us": "Libo LuLu"
+          }
+        },
+        {
+          "identifier": [
+            "Yuyi"
+          ],
+          "name": {
+            "en-us": "Libo Lina"
+          }
+        },
+        {
+          "identifier": [
+            "LuWuShuang"
+          ],
+          "name": {
+            "en-us": "Libo Adel"
+          }
+        },
+        {
+          "identifier": [
+            "LiBo"
+          ],
+          "name": {
+            "en-us": "Libo Lily"
+          }
+        },
+        {
+          "identifier": [
+            "QingTing"
+          ],
+          "name": {
+            "en-us": "Libo Lucy"
+          }
+        },
+        {
+          "identifier": [
+            "Huohu"
+          ],
+          "name": {
+            "en-us": "Libo Lara"
+          }
+        },
+        {
+          "identifier": [
+            "BaiHu"
+          ],
+          "name": {
+            "en-us": "Libo LaLa"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                100,
+                3
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Gugudai"
+          ],
+          "name": {
+            "en-us": "Libo Carlos"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                100,
+                3
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "magic-motion-1": {
+      "btle": {
+        "names": [
+          "Smart Mini Vibe*",
+          "Flamingo",
+          "Smart Bean",
+          "Magic Cell",
+          "Magic Wand",
+          "Fugu"
+        ],
+        "services": {
+          "78667579-7b48-43db-b8c5-7928a6b0a335": {
+            "tx": "78667579-a914-49a4-8333-aa3c0cd8fedc"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              100
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Smart Mini Vibe"
+          ],
+          "name": {
+            "en-us": "MagicMotion Smart Mini Vibe"
+          }
+        },
+        {
+          "identifier": [
+            "Smart Mini Vibe3"
+          ],
+          "name": {
+            "en-us": "MagicMotion Vini"
+          }
+        },
+        {
+          "identifier": [
+            "Flamingo"
+          ],
+          "name": {
+            "en-us": "MagicMotion Flamingo"
+          }
+        },
+        {
+          "identifier": [
+            "Magic Bean"
+          ],
+          "name": {
+            "en-us": "MagicMotion Kegel"
+          }
+        },
+        {
+          "identifier": [
+            "Magic Cell"
+          ],
+          "name": {
+            "en-us": "MagicMotion Dante/Candy"
+          }
+        },
+        {
+          "identifier": [
+            "Magic Wand"
+          ],
+          "name": {
+            "en-us": "MagicMotion Wand"
+          }
+        },
+        {
+          "identifier": [
+            "Magic Fugu"
+          ],
+          "name": {
+            "en-us": "MagicMotion Fugu"
+          }
+        }
+      ]
+    },
+    "magic-motion-2": {
+      "btle": {
+        "names": [
+          "Eidolon",
+          "Lipstick",
+          "Sword",
+          "Curve"
+        ],
+        "services": {
+          "78667579-7b48-43db-b8c5-7928a6b0a335": {
+            "tx": "78667579-a914-49a4-8333-aa3c0cd8fedc"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              100
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Lipstick"
+          ],
+          "name": {
+            "en-us": "MagicMotion Awaken"
+          }
+        },
+        {
+          "identifier": [
+            "Sword"
+          ],
+          "name": {
+            "en-us": "MagicMotion Equinox"
+          }
+        },
+        {
+          "identifier": [
+            "Curve"
+          ],
+          "name": {
+            "en-us": "MagicMotion Solstice"
+          }
+        },
+        {
+          "identifier": [
+            "Eidolon"
+          ],
+          "name": {
+            "en-us": "MagicMotion Eidolon"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                100
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "magic-motion-3": {
+      "btle": {
+        "names": [
+          "Krush"
+        ],
+        "services": {
+          "78667579-7b48-43db-b8c5-7928a6b0a335": {
+            "tx": "78667579-a914-49a4-8333-aa3c0cd8fedc"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              77
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Krush"
+          ],
+          "name": {
+            "en-us": "LoveLife Krush"
+          }
+        }
+      ]
+    },
+    "mysteryvibe": {
+      "btle": {
+        "names": [
+          "MV Crescendo",
+          "MV Tenuto*"
+        ],
+        "services": {
+          "f0006900-110c-478b-b74b-6f403b364a9c": {
+            "txmode": "f0006901-110c-478b-b74b-6f403b364a9c",
+            "txvibrate": "f0006903-110c-478b-b74b-6f403b364a9c"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 6,
+            "StepCount": [
+              56,
+              56,
+              56,
+              56,
+              56,
+              56
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "MV Crescendo"
+          ],
+          "name": {
+            "en-us": "MysteryVibe Crescendo"
+          }
+        },
+        {
+          "identifier": [
+            "MV Tenuto"
+          ],
+          "name": {
+            "en-us": "MysteryVibe Tenuto"
+          }
+        }
+      ]
+    },
+    "picobong": {
+      "btle": {
+        "names": [
+          "Blow hole",
+          "Picobong Male Toy",
+          "Diver",
+          "Picobong Egg",
+          "Life guard",
+          "Picobong Ring",
+          "Surfer",
+          "Picobong Butt Plug",
+          "Egg driver",
+          "Surfer_plug"
+        ],
+        "services": {
+          "0000fff0-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000fff1-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              10
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Blow hole",
+            "Picobong Male Toy"
+          ],
+          "name": {
+            "en-us": "Picobong Blow hole"
+          }
+        },
+        {
+          "identifier": [
+            "Diver",
+            "Picobong Egg"
+          ],
+          "name": {
+            "en-us": "Picobong Diver"
+          }
+        },
+        {
+          "identifier": [
+            "Life guard",
+            "Picobong Ring"
+          ],
+          "name": {
+            "en-us": "Picobong Life guard"
+          }
+        },
+        {
+          "identifier": [
+            "Surfer",
+            "Picobong Butt Plug",
+            "Egg driver",
+            "Surfer_plug"
+          ],
+          "name": {
+            "en-us": "Picobong Surfer"
+          }
+        }
+      ]
+    },
+    "vibratissimo": {
+      "btle": {
+        "names": [
+          "Vibratissimo"
+        ],
+        "services": {
+          "00001523-1212-efde-1523-785feabcd123": {
+            "txmode": "00001524-1212-efde-1523-785feabcd123",
+            "txvibrate": "00001526-1212-efde-1523-785feabcd123",
+            "rx": "00001527-1212-efde-1523-785feabcd123"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              255
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Vibratissimo"
+          ],
+          "name": {
+            "en-us": "Vibratissimo"
+          }
+        }
+      ]
+    },
+    "wevibe": {
+      "btle": {
+        "names": [
+          "Cougar",
+          "4 Plus",
+          "4_Plus",
+          "4plus",
+          "Bloom",
+          "classic",
+          "Classic",
+          "Ditto",
+          "Gala",
+          "Jive",
+          "Melt",
+          "Nova",
+          "NOVAV2",
+          "Pivot",
+          "Rave",
+          "Sync",
+          "Verge",
+          "Wish"
+        ],
+        "services": {
+          "f000bb03-0451-4000-b000-000000000000": {
+            "tx": "f000c000-0451-4000-b000-000000000000",
+            "rx": "f000b000-0451-4000-b000-000000000000"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              15
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Bloom"
+          ],
+          "name": {
+            "en-us": "WeVibe Bloom"
+          }
+        },
+        {
+          "identifier": [
+            "Ditto"
+          ],
+          "name": {
+            "en-us": "WeVibe Ditto"
+          }
+        },
+        {
+          "identifier": [
+            "Jive"
+          ],
+          "name": {
+            "en-us": "WeVibe Jive"
+          }
+        },
+        {
+          "identifier": [
+            "Melt"
+          ],
+          "name": {
+            "en-us": "WeVibe Melt"
+          }
+        },
+        {
+          "identifier": [
+            "Pivot"
+          ],
+          "name": {
+            "en-us": "WeVibe Pivot"
+          }
+        },
+        {
+          "identifier": [
+            "Rave"
+          ],
+          "name": {
+            "en-us": "WeVibe Rave"
+          }
+        },
+        {
+          "identifier": [
+            "Verge"
+          ],
+          "name": {
+            "en-us": "WeVibe Verge"
+          }
+        },
+        {
+          "identifier": [
+            "Wish"
+          ],
+          "name": {
+            "en-us": "WeVibe Wish"
+          }
+        },
+        {
+          "identifier": [
+            "Cougar",
+            "4 Plus",
+            "4_Plus",
+            "4plus",
+            "classic",
+            "Classic"
+          ],
+          "name": {
+            "en-us": "WeVibe 4 Plus"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                15,
+                15
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Gala"
+          ],
+          "name": {
+            "en-us": "WeVibe Gala"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                15,
+                15
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Nova",
+            "NOVAV2"
+          ],
+          "name": {
+            "en-us": "WeVibe Nova"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                15,
+                15
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Sync"
+          ],
+          "name": {
+            "en-us": "WeVibe Sync"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                15,
+                15
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "wevibe-8bit": {
+      "btle": {
+        "names": [
+          "Moxie",
+          "Vector"
+        ],
+        "services": {
+          "f000bb03-0451-4000-b000-000000000000": {
+            "tx": "f000c000-0451-4000-b000-000000000000",
+            "rx": "f000b000-0451-4000-b000-000000000000"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              12
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Moxie"
+          ],
+          "name": {
+            "en-us": "WeVibe Moxie"
+          }
+        },
+        {
+          "identifier": [
+            "Vector"
+          ],
+          "name": {
+            "en-us": "WeVibe Vector"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                12,
+                12
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "wevibe-legacy": {
+      "btle": {
+        "names": [
+          "Rey",
+          "We-Vibe Rocketman",
+          "Reina",
+          "imassager",
+          "Interactive Massager",
+          "03"
+        ],
+        "services": {
+          "f000bb03-0451-4000-b000-000000000000": {
+            "tx": "f000c000-0451-4000-b000-000000000000",
+            "rx": "f000b000-0451-4000-b000-000000000000"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {}
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Rey",
+            "We-Vibe Rocketman"
+          ],
+          "name": {
+            "en-us": "WeVibe Realm Rey"
+          }
+        },
+        {
+          "identifier": [
+            "Reina",
+            "imassager",
+            "Interactive Massager",
+            "03"
+          ],
+          "name": {
+            "en-us": "WeVibe Realm Reina"
+          }
+        }
+      ]
+    },
+    "youcups": {
+      "btle": {
+        "names": [
+          "Youcups"
+        ],
+        "services": {
+          "0000fee9-0000-1000-8000-00805f9b34fb": {
+            "tx": "d44bc439-abfd-45a2-b575-925416129600"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              8
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Youcups"
+          ],
+          "name": {
+            "en-us": "Youcups Warrior II"
+          }
+        }
+      ]
+    },
+    "cueme": {
+      "btle": {
+        "names": [
+          "FUNCODE_*"
+        ],
+        "services": {
+          "0000fff0-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000fff1-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 8,
+            "StepCount": [
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15,
+              15
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "1"
+          ],
+          "name": {
+            "en-us": "Cueme Mens"
+          }
+        },
+        {
+          "identifier": [
+            "2"
+          ],
+          "name": {
+            "en-us": "Cueme Bra"
+          }
+        },
+        {
+          "identifier": [
+            "3"
+          ],
+          "name": {
+            "en-us": "Cueme Womans"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 4,
+              "StepCount": [
+                15,
+                15,
+                15,
+                15
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "kiiroo-v2-vibrator": {
+      "btle": {
+        "names": [
+          "Pearl2",
+          "Fuse",
+          "Virtual Blowbot",
+          "Titan"
+        ],
+        "services": {
+          "88f82580-0000-01e6-aace-0002a5d5c51b": {
+            "tx": "88f82581-0000-01e6-aace-0002a5d5c51b",
+            "rxtouch": "88f82582-0000-01e6-aace-0002a5d5c51b",
+            "rxaccel": "88f82584-0000-01e6-aace-0002a5d5c51b"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 3,
+            "StepCount": [
+              100,
+              100,
+              100
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Pearl2"
+          ],
+          "name": {
+            "en-us": "Kiiroo Pearl 2"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                100
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Fuse"
+          ],
+          "name": {
+            "en-us": "OhMiBod Fuse"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                100,
+                100
+              ],
+              "FeatureOrder": [
+                1,
+                0
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Virtual Blowbot"
+          ],
+          "name": {
+            "en-us": "PornHub Virtual Blowbot"
+          }
+        },
+        {
+          "identifier": [
+            "Titan"
+          ],
+          "name": {
+            "en-us": "Kiiroo Titan"
+          }
+        }
+      ]
+    },
+    "kiiroo-v21": {
+      "btle": {
+        "names": [
+          "Onyx2.1",
+          "Titan1.1",
+          "Cliona",
+          "Pearl2.1",
+          "OhMiBod 4.0"
+        ],
+        "services": {
+          "00001900-0000-1000-8000-00805f9b34fb": {
+            "whitelist": "00001901-0000-1000-8000-00805f9b34fb",
+            "tx": "00001902-0000-1000-8000-00805f9b34fb",
+            "rx": "00001903-0000-1000-8000-00805f9b34fb"
+          },
+          "a0d70001-4c16-4ba7-977a-d394920e13a3": {
+            "tx": "a0d70002-4c16-4ba7-977a-d394920e13a3",
+            "rx": "a0d70003-4c16-4ba7-977a-d394920e13a3"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {}
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Pearl2.1"
+          ],
+          "name": {
+            "en-us": "Kiiroo Pearl 2.1"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                100
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Cliona"
+          ],
+          "name": {
+            "en-us": "Kiiroo Cliona"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                100
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "OhMiBod 4.0"
+          ],
+          "name": {
+            "en-us": "OhMiBod Esca 2"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                100
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Titan1.1"
+          ],
+          "name": {
+            "en-us": "Kiiroo Titan 1.1"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                100
+              ]
+            },
+            "LinearCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                99
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Onyx2.1"
+          ],
+          "name": {
+            "en-us": "Kiiroo Onyx 2.1"
+          },
+          "messages": {
+            "LinearCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                99
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "erostek-et312": {
+      "serial": {
+        "baud-rate": 19200,
+        "data-bits": 8,
+        "parity": "N",
+        "stop-bits": 1
+      },
+      "defaults": {
+        "messages": {
+          "LinearCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              99
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "et312"
+          ],
+          "name": {
+            "en-us": "Erostek ET312"
+          }
+        }
+      ]
+    },
+    "vorze-cyclone-x": {
+      "hid": {
+        "vendor-id": 1155,
+        "product-id": 22352
+      },
+      "defaults": {
+        "messages": {
+          "RotateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              10
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "CycloneX10"
+          ],
+          "name": {
+            "en-us": "Rends Cyclone X10"
+          }
+        }
+      ]
+    },
+    "rez-trancevibrator": {
+      "usb": {
+        "vendor-id": 2889,
+        "product-id": 1615
+      },
+      "defaults": {
+        "messages": {
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              255
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Trancevibrator"
+          ],
+          "name": {
+            "en-us": "Rez Trancevibrator"
+          }
+        }
+      ]
+    },
+    "kiiroo-v1": {
+      "btle": {
+        "names": [
+          "ONYX",
+          "PEARL"
+        ],
+        "services": {
+          "49535343-fe7d-4ae5-8fa9-9fafd205e455": {
+            "rx": "49535343-1e4d-4bd9-ba61-23c647249616",
+            "tx": "49535343-8841-43f4-a8d4-ecbe34729bb3",
+            "command": "49535343-aca3-481c-91ec-d85e28a60318",
+            "cmd2": "49535343-6daa-4d02-abf6-19569aca69fe"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {}
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "PEARL"
+          ],
+          "name": {
+            "en-us": "Kiiroo Pearl"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                4
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "ONYX"
+          ],
+          "name": {
+            "en-us": "Kiiroo Onyx"
+          },
+          "messages": {
+            "LinearCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                4
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "vorze-sa": {
+      "btle": {
+        "names": [
+          "Bach smart",
+          "CycSA",
+          "UFOSA"
+        ],
+        "services": {
+          "40ee1111-63ec-4b7f-8ce7-712efd55b90e": {
+            "tx": "40ee2222-63ec-4b7f-8ce7-712efd55b90e"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {}
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Bach smart"
+          ],
+          "name": {
+            "en-us": "Vorze Bach"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                100
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "CycSA"
+          ],
+          "name": {
+            "en-us": "Vorze A10 Cyclone SA"
+          },
+          "messages": {
+            "RotateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                99
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "UFOSA"
+          ],
+          "name": {
+            "en-us": "Vorze UFO SA"
+          },
+          "messages": {
+            "RotateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                99
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "youou": {
+      "btle": {
+        "names": [
+          "VX001_*"
+        ],
+        "services": {
+          "0000fff0-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000fff6-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              255
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "VX001_"
+          ],
+          "name": {
+            "en-us": "Youou Wand Vibrator"
+          }
+        }
+      ]
+    },
+    "realtouch": {
+      "hid": {
+        "vendor-id": 8020,
+        "product-id": 1
+      },
+      "defaults": {
+        "messages": {
+          "LinearCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              99
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "RealTouch"
+          ],
+          "name": {
+            "en-us": "RealTouch"
+          }
+        }
+      ]
+    },
+    "prettylove": {
+      "btle": {
+        "names": [
+          "Aogu BLE *"
+        ],
+        "services": {
+          "0000ffe5-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000ffe9-0000-1000-8000-00805f9b34fb",
+            "rx": "0000ffe2-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              3
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Aogu BLE"
+          ],
+          "name": {
+            "en-us": "Pretty Love Device"
+          }
+        }
+      ]
+    },
+    "svakom": {
+      "btle": {
+        "names": [
+          "Aogu SCB"
+        ],
+        "services": {
+          "0000ffe0-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000ffe1-0000-1000-8000-00805f9b34fb",
+            "rx": "0000ffe2-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              19
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Aogu SCB"
+          ],
+          "name": {
+            "en-us": "Svakom Ella"
+          }
+        }
+      ]
+    },
+    "realov": {
+      "btle": {
+        "names": [
+          "REALOV_VIBE"
+        ],
+        "services": {
+          "0000ffe0-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000ffe1-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              50
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "REALOV_VIBE"
+          ],
+          "name": {
+            "en-us": "Realov Device"
+          }
+        }
+      ]
+    },
+    "motorbunny": {
+      "btle": {
+        "names": [
+          "MB Controller"
+        ],
+        "services": {
+          "0000fff0-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000fff6-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              255
+            ]
+          },
+          "RotateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              255
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "MB Controller"
+          ],
+          "name": {
+            "en-us": "Motorbunny"
+          }
+        }
+      ]
+    },
+    "zalo": {
+      "btle": {
+        "names": [
+          "ZALO-Queen"
+        ],
+        "services": {
+          "0000fff0-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000fff1-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 2,
+            "StepCount": [
+              7,
+              7
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "ZALO-Queen"
+          ],
+          "name": {
+            "en-us": "Zalo Queen"
+          }
+        }
+      ]
+    },
+    "sayberx": {
+      "btle": {
+        "names": [
+          "SayberX",
+          "X-Ring *"
+        ],
+        "services": {
+          "0000fff0-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000fff6-0000-1000-8000-00805f9b34fb",
+            "rx": "0000fff8-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {}
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "SayberX"
+          ],
+          "name": {
+            "en-us": "SayberX"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                4
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "X-Ring"
+          ],
+          "name": {
+            "en-us": "Sayber X-Ring"
+          }
+        }
+      ]
+    },
+    "muse": {
+      "btle": {
+        "names": [
+          "WB-ZDB-WST",
+          "WB-TDD"
+        ],
+        "services": {
+          "0000aaa0-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000aaa1-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              9
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "WB-ZDB-WST"
+          ],
+          "name": {
+            "en-us": "Dream Lover Archer 2"
+          }
+        },
+        {
+          "identifier": [
+            "WB-TDD"
+          ],
+          "name": {
+            "en-us": "Galaku Panty Vib"
+          }
+        }
+      ]
+    },
+    "lelo-f1s": {
+      "btle": {
+        "names": [
+          "F1s"
+        ],
+        "services": {
+          "0000fff0-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000fff1-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 2,
+            "StepCount": [
+              100,
+              100
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "F1s"
+          ],
+          "name": {
+            "en-us": "Lelo F1s"
+          }
+        }
+      ]
+    },
+    "aneros": {
+      "btle": {
+        "names": [
+          "Massage Demo"
+        ],
+        "services": {
+          "0000ff00-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000ff01-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 2,
+            "StepCount": [
+              127
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Massage Demo"
+          ],
+          "name": {
+            "en-us": "Aneros Vivi"
+          }
+        }
+      ]
+    },
+    "lovehoney-desire": {
+      "btle": {
+        "names": [
+          "PROSTATE VIBE",
+          "KNICKER VIBE"
+        ],
+        "services": {
+          "0000ff00-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000ff01-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 2,
+            "StepCount": [
+              127,
+              127
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "PROSTATE VIBE"
+          ],
+          "name": {
+            "en-us": "Lovehoney Desire Prostate Vibrator"
+          }
+        },
+        {
+          "identifier": [
+            "KNICKER VIBE"
+          ],
+          "name": {
+            "en-us": "Lovehoney Desire Knicker Vibrator"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                127
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "twerkingbutt": {
+      "btle": {
+        "names": [
+          "BODIKANG",
+          "Twerking Butt",
+          "TwerkingButt"
+        ],
+        "services": {
+          "00000a60-0000-1000-8000-00805f9b34fb": {
+            "tx": "00000a66-0000-1000-8000-00805f9b34fb",
+            "rx": "00000a67-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {}
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "BODIKANG",
+            "Twerking Butt",
+            "TwerkingButt"
+          ],
+          "name": {
+            "en-us": "Lovehoney Desire Prostate Vibrator"
           }
         }
       ]

--- a/dependencies/buttplug-device-config/buttplug-device-config.yml
+++ b/dependencies/buttplug-device-config/buttplug-device-config.yml
@@ -266,7 +266,7 @@ protocols:
         LinearCmd:
           FeatureCount: 1
           StepCount:
-            - 100
+            - 99
         BatteryLevelCmd: {}
         RSSILevelCmd: {}
     configurations:
@@ -278,317 +278,1154 @@ protocols:
           - Onyx2
         name:
           en-us: Kiiroo Onyx 2
-  # libo:
-  #     btle:
-  #       names:
-  #         - PiPiJing # Whale/ELLE - Shock Egg
-  #         - XiaoLu # Lottie - Rabbit
-  #         - LuXiaoHan # LuLu - Egg
-  #         - SuoYinQiu # Karen - Kegel
-  #         - BaiHu # LaLa - Suction Rabbit
-  #         - MonsterPub # Sistalk MonsterPub (all 6?)
-  #         - Gugudai # Carlos - Suction Chicken
-  #         - ShaYu # Shark - Enflating Rabbit
-  #         - Yuyi # Lina - Leaf
-  #         - LuWuShuang # Adel - Curved Rabbit
-  #         - LiBo # Lily - Double ended mini wand
-  #         - QingTing # Lucy - Dragonfly egg
-  #         - Shuidi # ELLE2 - Shock Egg
-  #         - Huohu # Sexy Fox - Rabbit
-  #       services:
-  #         # Write Service
-  #         00006000-0000-1000-8000-00805f9b34fb:
-  #           tx: 00006001-0000-1000-8000-00805f9b34fb
-  #           txmode: 00006002-0000-1000-8000-00805f9b34fb
-  #         # Read Service (battery)
-  #         # 00006050-0000-1000-8000-00805f9b34fb:
-  #         #   battery: 00006051-0000-1000-8000-00805f9b34fb
-  #         # 00006070-0000-1000-8000-00805f9b34fb:
-  #         #   battery: 00006071-0000-1000-8000-00805f9b34fb
-  #         # Read Service (pressue)
-  #         # 00006050-0000-1000-8000-00805f9b34fb:
-  #         #   battery: 00006051-0000-1000-8000-00805f9b34fb
-  # magic-motion:
-  #   btle:
-  #     names:
-  #       - Smart Mini Vibe*
-  #       - Flamingo
-  #       - Eidolon
-  #       - Smart Bean # Magic Kegel Twins/Master/Master V2
-  #       - Magic Cell # Candy/Dante
-  #       - Magic Wand
-  #       - Fugu
-  #       - Krush # Lovelife Krush
-  #       - Lipstick # Awaken
-  #       - Sword # Equinox
-  #       - Curve # Solstice
-  #     services:
-  #       78667579-7b48-43db-b8c5-7928a6b0a335:
-  #         tx: 78667579-a914-49a4-8333-aa3c0cd8fedc
-  # mysteryvibe:
-  #   btle:
-  #     names:
-  #       - MV Crescendo
-  #       # Tenuto contains trailing spaces, so just deal with that
-  #       # using a wildcard.
-  #       - MV Tenuto*
-  #     services:
-  #       f0006900-110c-478b-b74b-6f403b364a9c:
-  #         txmode: f0006901-110c-478b-b74b-6f403b364a9c
-  #         txvibrate: f0006903-110c-478b-b74b-6f403b364a9c
-  # picobong:
-  #   btle:
-  #     names:
-  #       - Blow hole
-  #       - Picobong Male Toy
-  #       - Diver
-  #       - Picobong Egg
-  #       - Life guard
-  #       - Picobong Ring
-  #       - Surfer
-  #       - Picobong Butt Plug
-  #       - Egg driver
-  #       - Surfer_plug
-  #     services:
-  #       0000fff0-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000fff1-0000-1000-8000-00805f9b34fb
-  # vibratissimo:
-  #   btle:
-  #     names:
-  #       - Vibratissimo
-  #     services:
-  #       00001523-1212-efde-1523-785feabcd123:
-  #         txmode: 00001524-1212-efde-1523-785feabcd123
-  #         txvibrate: 00001526-1212-efde-1523-785feabcd123
-  #         rx: 00001527-1212-efde-1523-785feabcd123
-  # wevibe:
-  #   btle:
-  #     names:
-  #       - Cougar
-  #       - 4 Plus
-  #       - 4_Plus
-  #       - 4plus
-  #       - Bloom
-  #       - classic
-  #       - Classic
-  #       - Ditto
-  #       - Gala
-  #       - Jive
-  #       - Melt
-  #       - Moxie
-  #       - Nova
-  #       - NOVAV2
-  #       - Pivot
-  #       - Rey # Branded Realm
-  #       - We-Vibe Rocketman # Rey alias
-  #       - Rave
-  #       - Reina # Branded Realm
-  #       - imassager # Reina alias
-  #       - Interactive Massager # Reina alias
-  #       - "03" # Reina alias
-  #       - Sync
-  #       - Vector
-  #       - Verge
-  #       - Wish
-  #     services:
-  #       f000bb03-0451-4000-b000-000000000000:
-  #         tx: f000c000-0451-4000-b000-000000000000
-  #         rx: f000b000-0451-4000-b000-000000000000
-  # youcups:
-  #   btle:
-  #     names:
-  #       - Youcups
-  #     services:
-  #       0000fee9-0000-1000-8000-00805f9b34fb:
-  #         tx: d44bc439-abfd-45a2-b575-925416129600
-  # cueme:
-  #   btle:
-  #     names:
-  #       # Cueme names have the bluetooth address in the middle because
-  #       # sure. Why not. Of course they do.
-  #       - FUNCODE_*
-  #     services:
-  #       0000fff0-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000fff1-0000-1000-8000-00805f9b34fb
-  # kiiroo-v2-vibrator:
-  #   btle:
-  #     names:
-  #       - Pearl2
-  #       - Fuse
-  #       - Virtual Blowbot
-  #       - Titan
-  #     services:
-  #       88f82580-0000-01e6-aace-0002a5d5c51b:
-  #         tx: 88f82581-0000-01e6-aace-0002a5d5c51b
-  #         rxtouch: 88f82582-0000-01e6-aace-0002a5d5c51b
-  #         rxaccel: 88f82584-0000-01e6-aace-0002a5d5c51b
-  # kiiroo-v21:
-  #   btle:
-  #     names:
-  #       - Onyx2.1
-  #       - Titan1.1
-  #     services:
-  #       00001900-0000-1000-8000-00805f9b34fb:
-  #         # Used to clear the whitelist
-  #         whitelist: 00001901-0000-1000-8000-00805f9b34fb
-  #         tx: 00001902-0000-1000-8000-00805f9b34fb
-  #         rx: 00001903-0000-1000-8000-00805f9b34fb
-  # kiiroo-v21-vibrator:
-  #   btle:
-  #     names:
-  #       - Cliona
-  #       - Pearl2.1
-  #       - OhMiBod 4.0
-  #     services:
-  #       00001900-0000-1000-8000-00805f9b34fb:
-  #         # Used to clear the whitelist?
-  #         whitelist: 00001901-0000-1000-8000-00805f9b34fb
-  #         tx: 00001902-0000-1000-8000-00805f9b34fb
-  #         rx: 00001903-0000-1000-8000-00805f9b34fb
-  #       a0d70001-4c16-4ba7-977a-d394920e13a3:
-  #         tx: a0d70002-4c16-4ba7-977a-d394920e13a3
-  #         rx: a0d70003-4c16-4ba7-977a-d394920e13a3
-  # erostek-et312:
-  #   serial:
-  #     # Port names are defined in user configs
-  #     baud-rate: 19200
-  #     data-bits: 8
-  #     parity: N
-  #     stop-bits: 1
-  # vorze-cyclone-x:
-  #   hid:
-  #     vendor-id: 0x0483
-  #     product-id: 0x5750
-  # rez-trancevibrator:
-  #   usb:
-  #     vendor-id: 0xb49
-  #     product-id: 0x064f
-  # kiiroo-v1:
-  #   btle:
-  #     names:
-  #       - ONYX
-  #       - PEARL
-  #     services:
-  #       49535343-fe7d-4ae5-8fa9-9fafd205e455:
-  #         rx: 49535343-1e4d-4bd9-ba61-23c647249616
-  #         tx: 49535343-8841-43f4-a8d4-ecbe34729bb3
-  #         command: 49535343-aca3-481c-91ec-d85e28a60318
-  #         cmd2: 49535343-6daa-4d02-abf6-19569aca69fe
-  # vorze-sa:
-  #   btle:
-  #     names:
-  #       - CycSA
-  #       - Bach smart
-  #       - UFOSA
-  #     services:
-  #       40ee1111-63ec-4b7f-8ce7-712efd55b90e:
-  #         tx: 40ee2222-63ec-4b7f-8ce7-712efd55b90e
-  # youou:
-  #   btle:
-  #     names:
-  #       - VX001_*
-  #     services:
-  #       0000fff0-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000fff6-0000-1000-8000-00805f9b34fb
-  # realtouch:
-  #   hid:
-  #     vendor-id: 0x1f54
-  #     product-id: 0x0001
-  # prettylove:
-  #   btle:
-  #     names:
-  #       - Aogu BLE *
-  #     services:
-  #       0000ffe5-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000ffe9-0000-1000-8000-00805f9b34fb
-  #         rx: 0000ffe2-0000-1000-8000-00805f9b34fb
-  # svakom:
-  #   btle:
-  #     names:
-  #       - Aogu SCB # Ella
-  #     services:
-  #       0000ffe0-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000ffe1-0000-1000-8000-00805f9b34fb
-  #         rx: 0000ffe2-0000-1000-8000-00805f9b34fb
-  # realov:
-  #   btle:
-  #     names:
-  #       - REALOV_VIBE
-  #     services:
-  #       0000ffe0-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000ffe1-0000-1000-8000-00805f9b34fb
-  # motorbunny:
-  #   btle:
-  #     names:
-  #       - MB Controller
-  #     services:
-  #       0000fff0-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000fff6-0000-1000-8000-00805f9b34fb
-  #         # Motorbunny has a WRITE/NOTIFY characteristic, meaning rx/tx are the
-  #         # same characteristic. Do we support this? Not really sure it matters
-  #         # since I don't think we get any data off notify for this anyways?
-  #         #
-  #         # rx: 0000fff6-0000-1000-8000-00805f9b34fb
-  # zalo:
-  #   btle:
-  #     names:
-  #       - ZALO-Queen
-  #     services:
-  #       0000fff0-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000fff1-0000-1000-8000-00805f9b34fb
-  # sayberx:
-  #   btle:
-  #     names:
-  #       - SayberX
-  #       # - X-Ring *
-  #     services:
-  #       0000fff0-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000fff6-0000-1000-8000-00805f9b34fb
-  #         # No current way of marking services as optional
-  #         # rx: 0000fff8-0000-1000-8000-00805f9b34fb
-  # muse:
-  #   btle:
-  #     names:
-  #       - WB-ZDB-WST
-  #       - WB-TDD
-  #     services:
-  #       0000aaa0-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000aaa1-0000-1000-8000-00805f9b34fb
-  # lelo-f1s:
-  #   btle:
-  #     names:
-  #       - F1s
-  #     services:
-  #       0000fff0-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000fff1-0000-1000-8000-00805f9b34fb
-  #         # There are a LOT of sensor characteristics
-  #         # I figure we'll add them as support for those sensor
-  #         # types is added to Buttplug
-  # aneros:
-  #   btle:
-  #     names:
-  #       - Massage Demo
-  #     services:
-  #       0000ff00-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000ff01-0000-1000-8000-00805f9b34fb
-  # lovehoney-desire:
-  #   btle:
-  #     names:
-  #       - PROSTATE VIBE
-  #       - KNICKER VIBE
-  #     services:
-  #       0000ff00-0000-1000-8000-00805f9b34fb:
-  #         tx: 0000ff01-0000-1000-8000-00805f9b34fb
-  # twerkingbutt:
-  #   btle:
-  #     names:
-  #       - BODIKANG
-  #       - Twerking Butt
-  #       - TwerkingButt
-  #     services:
-  #       00000a60-0000-1000-8000-00805f9b34fb:
-  #         tx: 00000a66-0000-1000-8000-00805f9b34fb
-  #         rx: 00000a67-0000-1000-8000-00805f9b34fb
+  libo-elle:
+      btle:
+        names:
+          - PiPiJing # Whale/ELLE - Shock Egg
+          - Shuidi # ELLE2 - Shock Egg
+        services:
+          # Write Service
+          00006000-0000-1000-8000-00805f9b34fb:
+            tx: 00006001-0000-1000-8000-00805f9b34fb
+            txmode: 00006002-0000-1000-8000-00805f9b34fb
+      defaults:
+        messages:
+          BatteryLevelCmd: {}
+          RSSILevelCmd: {}
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 3  # Vibe
+              - 14 # Estim
+      configurations:
+        - identifier:
+            - PiPiJing
+          name:
+            en-us: LiBo Elle
+        - identifier:
+            - Shuidi
+          name:
+            en-us: Libo Elle 2
+  libo-shark:
+      btle:
+        names:
+          - ShaYu # Shark - Enflating Rabbit
+        services:
+          # Write Service
+          00006000-0000-1000-8000-00805f9b34fb:
+            tx: 00006001-0000-1000-8000-00805f9b34fb
+            txmode: 00006002-0000-1000-8000-00805f9b34fb
+      defaults:
+        messages:
+          BatteryLevelCmd: {}
+          RSSILevelCmd: {}
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 3
+              - 3
+      configurations:
+        - identifier:
+            - ShaYu
+          name:
+            en-us: Libo Shark
+  libo-karen:
+      btle:
+        names:
+          - SuoYinQiu # Karen - Kegel
+        services:
+          # Write Service
+          00006000-0000-1000-8000-00805f9b34fb:
+            tx: 00006001-0000-1000-8000-00805f9b34fb
+            txmode: 00006002-0000-1000-8000-00805f9b34fb
+          # pressure
+          00006050-0000-1000-8000-00805f9b34fb:
+            rxpressure: 00006051-0000-1000-8000-00805f9b34fb
+      defaults:
+        messages:
+          BatteryLevelCmd: {}
+          RSSILevelCmd: {}
+      configurations:
+        - identifier:
+            - SuoYinQiu
+          name:
+            en-us: Libo Karen
+  libo-vibes:
+      btle:
+        names:
+          - XiaoLu # Lottie - Rabbit
+          - LuXiaoHan # LuLu - Egg
+          - BaiHu # LaLa - Suction Rabbit
+          - MonsterPub # Sistalk MonsterPub (all 6?)
+          - Gugudai # Carlos - Suction Chicken
+          - Yuyi # Lina - Leaf
+          - LuWuShuang # Adel - Curved Rabbit
+          - LiBo # Lily - Double ended mini wand
+          - QingTing # Lucy - Dragonfly egg
+          - Huohu # Lara/Sexy Fox - Rabbit
+        services:
+          # Write Service
+          00006000-0000-1000-8000-00805f9b34fb:
+            tx: 00006001-0000-1000-8000-00805f9b34fb
+            txmode: 00006002-0000-1000-8000-00805f9b34fb
+      defaults:
+        messages:
+          BatteryLevelCmd: {}
+          RSSILevelCmd: {}
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+              - 100
+      configurations:
+        - identifier:
+            - XiaoLu
+          name:
+            en-us: Libo Lottie
+        - identifier:
+            - MonsterPub
+          name:
+            en-us: Sistalk MonsterPub
+        - identifier:
+            - LuXiaoHan
+          name:
+            en-us: Libo LuLu
+        - identifier:
+            - Yuyi
+          name:
+            en-us: Libo Lina
+        - identifier:
+            - LuWuShuang
+          name:
+            en-us: Libo Adel
+        - identifier:
+            - LiBo
+          name:
+            en-us: Libo Lily
+        - identifier:
+            - QingTing
+          name:
+            en-us: Libo Lucy
+        - identifier:
+            - Huohu
+          name:
+            en-us: Libo Lara
+        # Suction Vibes
+        - identifier:
+            - BaiHu
+          name:
+            en-us: Libo LaLa
+          messages:
+            VibrateCmd:
+              FeatureCount: 2
+              StepCount:
+                - 100
+                - 3
+        - identifier:
+            - Gugudai
+          name:
+            en-us: Libo Carlos
+          messages:
+            VibrateCmd:
+              FeatureCount: 2
+              StepCount:
+                - 100
+                - 3
+  magic-motion-1:
+    btle:
+      names:
+        - Smart Mini Vibe*
+        - Flamingo
+        - Smart Bean # Magic Kegel Twins/Master/Master V2
+        - Magic Cell # Candy/Dante
+        - Magic Wand
+        - Fugu
+      services:
+        78667579-7b48-43db-b8c5-7928a6b0a335:
+          tx: 78667579-a914-49a4-8333-aa3c0cd8fedc
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 100
+    configurations:
+      - identifier:
+          - Smart Mini Vibe
+        name:
+          en-us: MagicMotion Smart Mini Vibe
+      - identifier:
+          - Smart Mini Vibe3
+        name:
+          en-us: MagicMotion Vini
+      - identifier:
+          - Flamingo
+        name:
+          en-us: MagicMotion Flamingo
+      - identifier:
+          - Magic Bean
+        name:
+          en-us: MagicMotion Kegel
+      - identifier:
+          - Magic Cell
+        name:
+          en-us: MagicMotion Dante/Candy
+      - identifier:
+          - Magic Wand
+        name:
+          en-us: MagicMotion Wand
+      - identifier:
+          - Magic Fugu
+        name:
+          en-us: MagicMotion Fugu
+  magic-motion-2:
+    btle:
+      names:
+        - Eidolon
+        - Lipstick # Awaken
+        - Sword # Equinox
+        - Curve # Solstice
+      services:
+        78667579-7b48-43db-b8c5-7928a6b0a335:
+          tx: 78667579-a914-49a4-8333-aa3c0cd8fedc
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 100
+    configurations:
+      - identifier:
+          - Lipstick
+        name:
+          en-us: MagicMotion Awaken
+      - identifier:
+          - Sword
+        name:
+          en-us: MagicMotion Equinox
+      - identifier:
+          - Curve
+        name:
+          en-us: MagicMotion Solstice
+      - identifier:
+          - Eidolon
+        name:
+          en-us: MagicMotion Eidolon
+        messages:
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 100
+  magic-motion-3:
+    btle:
+      names:
+        - Krush # Lovelife Krush
+      services:
+        78667579-7b48-43db-b8c5-7928a6b0a335:
+          tx: 78667579-a914-49a4-8333-aa3c0cd8fedc
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 77
+    configurations:
+      - identifier:
+          - Krush 
+        name:
+          en-us: LoveLife Krush
+  mysteryvibe:
+    btle:
+      names:
+        - MV Crescendo
+        # Tenuto contains trailing spaces, so just deal with that
+        # using a wildcard.
+        - MV Tenuto*
+      services:
+        f0006900-110c-478b-b74b-6f403b364a9c:
+          txmode: f0006901-110c-478b-b74b-6f403b364a9c
+          txvibrate: f0006903-110c-478b-b74b-6f403b364a9c
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 6
+          StepCount:
+            - 56
+            - 56
+            - 56
+            - 56
+            - 56
+            - 56
+    configurations:
+      - identifier:
+          - MV Crescendo 
+        name:
+          en-us: MysteryVibe Crescendo
+      - identifier:
+          - MV Tenuto 
+        name:
+          en-us: MysteryVibe Tenuto
+  picobong:
+    btle:
+      names:
+        - Blow hole
+        - Picobong Male Toy
+        - Diver
+        - Picobong Egg
+        - Life guard
+        - Picobong Ring
+        - Surfer
+        - Picobong Butt Plug
+        - Egg driver
+        - Surfer_plug
+      services:
+        0000fff0-0000-1000-8000-00805f9b34fb:
+          tx: 0000fff1-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 10
+    configurations:
+      - identifier:
+          - Blow hole
+          - Picobong Male Toy
+        name:
+          en-us: Picobong Blow hole
+      - identifier:
+          - Diver
+          - Picobong Egg
+        name:
+          en-us: Picobong Diver
+      - identifier:
+          - Life guard
+          - Picobong Ring
+        name:
+          en-us: Picobong Life guard
+      - identifier:
+          - Surfer
+          - Picobong Butt Plug
+          - Egg driver
+          - Surfer_plug
+        name:
+          en-us: Picobong Surfer
+  vibratissimo:
+    btle:
+      names:
+        - Vibratissimo
+      services:
+        00001523-1212-efde-1523-785feabcd123:
+          txmode: 00001524-1212-efde-1523-785feabcd123
+          txvibrate: 00001526-1212-efde-1523-785feabcd123
+          rx: 00001527-1212-efde-1523-785feabcd123
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 255
+    configurations:
+      - identifier:
+          - Vibratissimo
+        name:
+          en-us: Vibratissimo
+  wevibe:
+    btle:
+      names:
+        - Cougar # 4 Plus alias
+        - 4 Plus
+        - 4_Plus # 4 Plus alias
+        - 4plus # 4 Plus alias
+        - Bloom
+        - classic # 4 Plus alias
+        - Classic # 4 Plus alias
+        - Ditto
+        - Gala
+        - Jive
+        - Melt
+        - Nova
+        - NOVAV2
+        - Pivot
+        - Rave
+        - Sync
+        - Verge
+        - Wish
+      services:
+        f000bb03-0451-4000-b000-000000000000:
+          tx: f000c000-0451-4000-b000-000000000000
+          rx: f000b000-0451-4000-b000-000000000000
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 15
+    configurations:
+      # Single Vibes
+      - identifier:
+          - Bloom
+        name:
+          en-us: WeVibe Bloom
+      - identifier:
+          - Ditto
+        name:
+          en-us: WeVibe Ditto
+      - identifier:
+          - Jive
+        name:
+          en-us: WeVibe Jive
+      - identifier:
+          - Melt
+        name:
+          en-us: WeVibe Melt
+      - identifier:
+          - Pivot
+        name:
+          en-us: WeVibe Pivot
+      - identifier:
+          - Rave
+        name:
+          en-us: WeVibe Rave
+      - identifier:
+          - Verge
+        name:
+          en-us: WeVibe Verge
+      - identifier:
+          - Wish
+        name:
+          en-us: WeVibe Wish
+      # Double Vibes
+      - identifier:
+          - Cougar
+          - 4 Plus
+          - 4_Plus
+          - 4plus
+          - classic
+          - Classic
+        name:
+          en-us: WeVibe 4 Plus
+        messages:
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 15
+              - 15
+      - identifier:
+          - Gala
+        name:
+          en-us: WeVibe Gala
+        messages:
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 15
+              - 15
+      - identifier:
+          - Nova
+          - NOVAV2
+        name:
+          en-us: WeVibe Nova
+        messages:
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 15
+              - 15
+      - identifier:
+          - Sync
+        name:
+          en-us: WeVibe Sync
+        messages:
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 15
+              - 15
+  wevibe-8bit:
+    btle:
+      names:
+        - Moxie
+        - Vector
+      services:
+        f000bb03-0451-4000-b000-000000000000:
+          tx: f000c000-0451-4000-b000-000000000000
+          rx: f000b000-0451-4000-b000-000000000000
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 12
+    configurations:
+      - identifier:
+          - Moxie
+        name:
+          en-us: WeVibe Moxie
+      - identifier:
+          - Vector
+        name:
+          en-us: WeVibe Vector
+        messages:
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 12
+              - 12
+  wevibe-legacy:
+    btle:
+      names:
+        - Rey # Branded Realm
+        - We-Vibe Rocketman # Rey alias
+        - Reina # Branded Realm
+        - imassager # Reina alias
+        - Interactive Massager # Reina alias
+        - "03" # Reina alias
+      services:
+        f000bb03-0451-4000-b000-000000000000:
+          tx: f000c000-0451-4000-b000-000000000000
+          rx: f000b000-0451-4000-b000-000000000000
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+    configurations:
+      - identifier:
+          - Rey
+          - We-Vibe Rocketman
+        name:
+          en-us: WeVibe Realm Rey
+      - identifier:
+          - Reina
+          - imassager
+          - Interactive Massager
+          - "03"
+        name:
+          en-us: WeVibe Realm Reina
+  youcups:
+    btle:
+      names:
+        - Youcups
+      services:
+        0000fee9-0000-1000-8000-00805f9b34fb:
+          tx: d44bc439-abfd-45a2-b575-925416129600
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 8
+    configurations:
+      - identifier:
+          - Youcups
+        name:
+          en-us: Youcups Warrior II
+  cueme:
+    btle:
+      names:
+        # Cueme names have the bluetooth address in the middle because
+        # sure. Why not. Of course they do.
+        - FUNCODE_*
+      services:
+        0000fff0-0000-1000-8000-00805f9b34fb:
+          tx: 0000fff1-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 8
+          StepCount:
+            - 15
+            - 15
+            - 15
+            - 15
+            - 15
+            - 15
+            - 15
+            - 15
+    configurations:
+      - identifier:
+          - "1"
+        name:
+          en-us: Cueme Mens
+      - identifier:
+          - "2"
+        name:
+          en-us: Cueme Bra
+      - identifier:
+          - "3"
+        name:
+          en-us: Cueme Womans
+        messages:
+          VibrateCmd:
+            FeatureCount: 4
+            StepCount:
+              - 15
+              - 15
+              - 15
+              - 15
+  kiiroo-v2-vibrator:
+    btle:
+      names:
+        - Pearl2
+        - Fuse
+        - Virtual Blowbot
+        - Titan
+      services:
+        88f82580-0000-01e6-aace-0002a5d5c51b:
+          tx: 88f82581-0000-01e6-aace-0002a5d5c51b
+          rxtouch: 88f82582-0000-01e6-aace-0002a5d5c51b
+          rxaccel: 88f82584-0000-01e6-aace-0002a5d5c51b
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 3
+          StepCount:
+           - 100
+           - 100
+           - 100
+    configurations:
+      - identifier:
+          - Pearl2
+        name:
+          en-us: Kiiroo Pearl 2
+        messages:
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+             - 100
+      - identifier:
+          - Fuse
+        name:
+          en-us: OhMiBod Fuse
+        messages:
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 100
+              - 100
+            FeatureOrder:
+              - 1
+              - 0
+      - identifier:
+          - Virtual Blowbot
+        name:
+          en-us: PornHub Virtual Blowbot
+      - identifier:
+          - Titan
+        name:
+          en-us: Kiiroo Titan
+  kiiroo-v21:
+    btle:
+      names:
+        - Onyx2.1
+        - Titan1.1
+        - Cliona
+        - Pearl2.1
+        - OhMiBod 4.0
+      services:
+        00001900-0000-1000-8000-00805f9b34fb:
+          # Used to clear the whitelist
+          whitelist: 00001901-0000-1000-8000-00805f9b34fb
+          tx: 00001902-0000-1000-8000-00805f9b34fb
+          rx: 00001903-0000-1000-8000-00805f9b34fb
+        a0d70001-4c16-4ba7-977a-d394920e13a3:
+          tx: a0d70002-4c16-4ba7-977a-d394920e13a3
+          rx: a0d70003-4c16-4ba7-977a-d394920e13a3
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+    configurations:
+      - identifier:
+          - Pearl2.1
+        name:
+          en-us: Kiiroo Pearl 2.1
+        messages:
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+             - 100
+      - identifier:
+          - Cliona
+        name:
+          en-us: Kiiroo Cliona
+        messages:
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+             - 100
+      - identifier:
+          - OhMiBod 4.0
+        name:
+          en-us: OhMiBod Esca 2
+        messages:
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+             - 100
+      - identifier:
+          - Titan1.1
+        name:
+          en-us: Kiiroo Titan 1.1
+        messages:
+          VibrateCmd:
+            FeatureCount: 1 # Actually 3, but havn't worked out how to map them yet
+            StepCount:
+             - 100
+          LinearCmd:
+            FeatureCount: 1
+            StepCount:
+              - 99
+      - identifier:
+          - Onyx2.1
+        name:
+          en-us: Kiiroo Onyx 2.1
+        messages:
+          LinearCmd:
+            FeatureCount: 1
+            StepCount:
+              - 99
+  erostek-et312:
+    serial:
+      # Port names are defined in user configs
+      baud-rate: 19200
+      data-bits: 8
+      parity: N
+      stop-bits: 1
+    defaults:
+      messages:
+        LinearCmd:
+          FeatureCount: 1
+          StepCount:
+            - 99
+    configurations:
+      - identifier:
+          - et312
+        name:
+          en-us: Erostek ET312
+  vorze-cyclone-x:
+    hid:
+      vendor-id: 0x0483
+      product-id: 0x5750
+    defaults:
+      messages:
+        RotateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 10
+    configurations:
+      - identifier:
+          - CycloneX10
+        name:
+          en-us: Rends Cyclone X10
+  rez-trancevibrator:
+    usb:
+      vendor-id: 0xb49
+      product-id: 0x064f
+    defaults:
+      messages:
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 255
+    configurations:
+      - identifier:
+          - Trancevibrator
+        name:
+          en-us: Rez Trancevibrator
+  kiiroo-v1:
+    btle:
+      names:
+        - ONYX
+        - PEARL
+      services:
+        49535343-fe7d-4ae5-8fa9-9fafd205e455:
+          rx: 49535343-1e4d-4bd9-ba61-23c647249616
+          tx: 49535343-8841-43f4-a8d4-ecbe34729bb3
+          command: 49535343-aca3-481c-91ec-d85e28a60318
+          cmd2: 49535343-6daa-4d02-abf6-19569aca69fe
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+    configurations:
+      - identifier:
+          - PEARL
+        name:
+          en-us: Kiiroo Pearl
+        messages:
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+             - 4
+      - identifier:
+          - ONYX
+        name:
+          en-us: Kiiroo Onyx
+        messages:
+          LinearCmd:
+            FeatureCount: 1
+            StepCount:
+              - 4
+  vorze-sa:
+    btle:
+      names:
+        - Bach smart
+        - CycSA
+        - UFOSA
+      services:
+        40ee1111-63ec-4b7f-8ce7-712efd55b90e:
+          tx: 40ee2222-63ec-4b7f-8ce7-712efd55b90e
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+    configurations:
+      - identifier:
+          - Bach smart
+        name:
+          en-us: Vorze Bach
+        messages:
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+             - 100
+      - identifier:
+          - CycSA
+        name:
+          en-us: Vorze A10 Cyclone SA
+        messages:
+          RotateCmd:
+            FeatureCount: 1
+            StepCount:
+              - 99
+      - identifier:
+          - UFOSA
+        name:
+          en-us: Vorze UFO SA
+        messages:
+          RotateCmd:
+            FeatureCount: 1
+            StepCount:
+              - 99
+  youou:
+    btle:
+      names:
+        - VX001_*
+      services:
+        0000fff0-0000-1000-8000-00805f9b34fb:
+          tx: 0000fff6-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+           - 255
+    configurations:
+      - identifier:
+          - VX001_
+        name:
+          en-us: Youou Wand Vibrator
+  realtouch:
+    hid:
+      vendor-id: 0x1f54
+      product-id: 0x0001
+    defaults:
+      messages:
+        LinearCmd:
+          FeatureCount: 1
+          StepCount:
+           - 99
+    configurations:
+      - identifier:
+          - RealTouch
+        name:
+          en-us: RealTouch
+  prettylove:
+    btle:
+      names:
+        - Aogu BLE *
+      services:
+        0000ffe5-0000-1000-8000-00805f9b34fb:
+          tx: 0000ffe9-0000-1000-8000-00805f9b34fb
+          rx: 0000ffe2-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+           - 3
+    configurations:
+      - identifier:
+          - Aogu BLE
+        name:
+          en-us: Pretty Love Device
+  svakom:
+    btle:
+      names:
+        - Aogu SCB # Ella
+      services:
+        0000ffe0-0000-1000-8000-00805f9b34fb:
+          tx: 0000ffe1-0000-1000-8000-00805f9b34fb
+          rx: 0000ffe2-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+           - 19
+    configurations:
+      - identifier:
+          - Aogu SCB
+        name:
+          en-us: Svakom Ella
+  realov:
+    btle:
+      names:
+        - REALOV_VIBE
+      services:
+        0000ffe0-0000-1000-8000-00805f9b34fb:
+          tx: 0000ffe1-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+           - 50
+    configurations:
+      - identifier:
+          - REALOV_VIBE
+        name:
+          en-us: Realov Device
+  motorbunny:
+    btle:
+      names:
+        - MB Controller
+      services:
+        0000fff0-0000-1000-8000-00805f9b34fb:
+          tx: 0000fff6-0000-1000-8000-00805f9b34fb
+          # Motorbunny has a WRITE/NOTIFY characteristic, meaning rx/tx are the
+          # same characteristic. Do we support this? Not really sure it matters
+          # since I don't think we get any data off notify for this anyways?
+          #
+          # rx: 0000fff6-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+           - 255
+        RotateCmd:
+          FeatureCount: 1
+          StepCount:
+           - 255
+    configurations:
+      - identifier:
+          - MB Controller
+        name:
+          en-us: Motorbunny
+  zalo:
+    btle:
+      names:
+        - ZALO-Queen
+      services:
+        0000fff0-0000-1000-8000-00805f9b34fb:
+          tx: 0000fff1-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 2
+          StepCount:
+           - 7
+           - 7
+    configurations:
+      - identifier:
+          - ZALO-Queen
+        name:
+          en-us: Zalo Queen
+  sayberx:
+    btle:
+      names:
+        - SayberX
+        - X-Ring *
+      services:
+        0000fff0-0000-1000-8000-00805f9b34fb:
+          tx: 0000fff6-0000-1000-8000-00805f9b34fb
+          rx: 0000fff8-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+    configurations:
+      - identifier:
+          - SayberX
+        name:
+          en-us: SayberX
+        messages:
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+             - 4
+      - identifier:
+          - X-Ring
+        name:
+          en-us: Sayber X-Ring
+  muse:
+    btle:
+      names:
+        - WB-ZDB-WST
+        - WB-TDD
+      services:
+        0000aaa0-0000-1000-8000-00805f9b34fb:
+          tx: 0000aaa1-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+           - 9
+    configurations:
+      - identifier:
+          - WB-ZDB-WST
+        name:
+          en-us: Dream Lover Archer 2
+      - identifier:
+          - WB-TDD
+        name:
+          en-us: Galaku Panty Vib
+  lelo-f1s:
+    btle:
+      names:
+        - F1s
+      services:
+        0000fff0-0000-1000-8000-00805f9b34fb:
+          tx: 0000fff1-0000-1000-8000-00805f9b34fb
+          # There are a LOT of sensor characteristics
+          # I figure we'll add them as support for those sensor
+          # types is added to Buttplug
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 2
+          StepCount:
+           - 100
+           - 100
+    configurations:
+      - identifier:
+          - F1s
+        name:
+          en-us: Lelo F1s
+  aneros:
+    btle:
+      names:
+        - Massage Demo
+      services:
+        0000ff00-0000-1000-8000-00805f9b34fb:
+          tx: 0000ff01-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 2
+          StepCount:
+           - 127
+    configurations:
+      - identifier:
+          - Massage Demo
+        name:
+          en-us: Aneros Vivi
+  lovehoney-desire:
+    btle:
+      names:
+        - PROSTATE VIBE
+        - KNICKER VIBE
+      services:
+        0000ff00-0000-1000-8000-00805f9b34fb:
+          tx: 0000ff01-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 2
+          StepCount:
+           - 127
+           - 127
+    configurations:
+      - identifier:
+          - PROSTATE VIBE
+        name:
+          en-us: Lovehoney Desire Prostate Vibrator
+      - identifier:
+          - KNICKER VIBE
+        name:
+          en-us: Lovehoney Desire Knicker Vibrator
+        messages:
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+             - 127
+  twerkingbutt:
+    btle:
+      names:
+        - BODIKANG
+        - Twerking Butt
+        - TwerkingButt
+      services:
+        00000a60-0000-1000-8000-00805f9b34fb:
+          tx: 00000a66-0000-1000-8000-00805f9b34fb
+          rx: 00000a67-0000-1000-8000-00805f9b34fb
+    defaults:
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        # Vibration and Rotation protocols still need to be establised
+        # Twerk mode will be represented as a vibrator
+    configurations:
+      - identifier:
+          - BODIKANG
+          - Twerking Butt
+          - TwerkingButt
+        name:
+          en-us: Lovehoney Desire Prostate Vibrator
   # nintendo-joycon:
   #   hid:
   #     vendor-id: 0x057e


### PR DESCRIPTION
All known devices (except the JoyCon) have been expanded as per
the new configuration atrributes scheme.

This change adds FeatureOrder to the GenericMessageAttributes block
and allows rxpressure as an endpoint name.