### PR TITLE
fix: Youou never sends vibe speeds of 0

### DIFF
--- a/Buttplug.Test/Devices/Protocols/YououTests.cs
+++ b/Buttplug.Test/Devices/Protocols/YououTests.cs
@@ -1,0 +1,101 @@
+﻿// <copyright file="YououTests.cs" company="Nonpolynomial Labs LLC">
+// Buttplug C# Source Code File - Visit https://buttplug.io for more info about the project.
+// Copyright (c) Nonpolynomial Labs LLC. All rights reserved.
+// Licensed under the BSD 3-Clause license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+// Test file, disable ConfigureAwait checking.
+// ReSharper disable ConsiderUsingConfigureAwait
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading.Tasks;
+using Buttplug.Core.Messages;
+using Buttplug.Devices;
+using Buttplug.Devices.Configuration;
+using Buttplug.Devices.Protocols;
+using Buttplug.Test.Devices.Protocols.Utils;
+using JetBrains.Annotations;
+using NUnit.Framework;
+
+namespace Buttplug.Test.Devices.Protocols
+{
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "Test classes can skip documentation requirements")]
+    [TestFixture]
+    public class YououTests
+    {
+        [NotNull]
+        private ProtocolTestUtils testUtil;
+
+        [SetUp]
+        public async Task Init()
+        {
+            testUtil = new ProtocolTestUtils();
+            await testUtil.SetupTest<YououProtocol>("Youou", new List<DeviceConfiguration>());
+        }
+
+        [Test]
+        public void TestAllowedMessages()
+        {
+            testUtil.TestDeviceAllowedMessages(new Dictionary<System.Type, uint>()
+            {
+                { typeof(StopDeviceCmd), 0 },
+                { typeof(SingleMotorVibrateCmd), 0 },
+                { typeof(VibrateCmd), 1 },
+            });
+        }
+
+        // StopDeviceCmd noop test handled in GeneralDeviceTests
+
+        [Test]
+        public async Task TestStopDeviceCmd()
+        {
+            var expected =
+                new List<(byte[], string)>()
+                {
+                    (new byte[] {0xAA, 0x55, 0x00, 0x02, 0x03, 0x01, 0x7B, 0x01, 0x85, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, Endpoints.Tx),
+                };
+
+            await testUtil.TestDeviceMessage(new SingleMotorVibrateCmd(4, 0.5), expected, false);
+
+            expected =
+                new List<(byte[], string)>()
+                {
+                    (new byte[] {0xAA, 0x55, 0x01, 0x02, 0x03, 0x01, 0x0, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, Endpoints.Tx),
+                };
+
+            await testUtil.TestDeviceMessage(new StopDeviceCmd(4), expected, false);
+        }
+
+        [Test]
+        public async Task TestSingleMotorVibrateCmd()
+        {
+            var expected =
+                new List<(byte[], string)>()
+                {
+                    (new byte[] {0xAA, 0x55, 0x00, 0x02, 0x03, 0x01, 0x7B, 0x01, 0x85, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, Endpoints.Tx),
+                };
+
+            await testUtil.TestDeviceMessage(new SingleMotorVibrateCmd(4, 0.5), expected, false);
+        }
+
+        [Test]
+        public async Task TestVibrateCmd()
+        {
+            var expected =
+                new List<(byte[], string)>()
+                {
+                    (new byte[] {0xAA, 0x55, 0x00, 0x02, 0x03, 0x01, 0x7B, 0x01, 0x85, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, Endpoints.Tx),
+                };
+
+            await testUtil.TestDeviceMessage(VibrateCmd.Create(4, 1, 0.5, 1), expected, false);
+        }
+
+        [Test]
+        public void TestInvalidVibrateCmd()
+        {
+            testUtil.TestInvalidVibrateCmd(1);
+        }
+    }
+}

--- a/Buttplug/Devices/Protocols/YououProtocol.cs
+++ b/Buttplug/Devices/Protocols/YououProtocol.cs
@@ -53,6 +53,7 @@ namespace Buttplug.Devices.Protocols
                 return new Ok(cmdMsg.Id);
             }
 
+            _vibratorSpeed = v.Speed;
             SentVibration = true;
 
             // Byte 2 seems to be a monotonically increasing packet id of some kind Speed seems to be


### PR DESCRIPTION
The _vibrationSpeed variable isn't updated, so on stop
the device already thinks it's stopped.