### PR TITLE
feat: Add support for Onyx+

### DIFF
--- a/Buttplug/Devices/Protocols/KiirooGen21Protocol.cs
+++ b/Buttplug/Devices/Protocols/KiirooGen21Protocol.cs
@@ -87,6 +87,17 @@ namespace Buttplug.Devices.Protocols
                     VibeOrder = new[] { 0u },
                 }
             },
+            {
+                "Onyx+",
+                new KiirooGen21Type
+                {
+                    Brand = "Kiiroo",
+                    Name = "Onyx+",
+                    HasLinear = true,
+                    VibeCount = 0,
+                    VibeOrder = new uint[0],
+                }
+            },
         };
 
         private readonly KiirooGen21Type _devInfo;


### PR DESCRIPTION
This change still requires the updated device config, but right now the device config alone will present the Onyx+ as a vibe.