### PR TITLE
fix: Exception on server disconnect -> ServerDisconnect is not raised

### DIFF
--- a/Buttplug/Client/ButtplugWebsocketConnector.cs
+++ b/Buttplug/Client/ButtplugWebsocketConnector.cs
@@ -132,7 +132,7 @@ namespace Buttplug.Client
                 if (_wsClient != null)
                 {
                     // Clean up the websocket and fire the disconnection event.
-                    _wsClient.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None).Dispose();
+                    _ = _wsClient.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
                     _wsClient = null;
                 }
                 // If we somehow still have some live messages, throw exceptions so they aren't stuck.


### PR DESCRIPTION
I get the following exception when stopping the server (Intiface Central 3.1.0 via the Stop button) while connected:

```
System.InvalidOperationException: A task may only be disposed if it is in a completion state (RanToCompletion, Faulted or Canceled).
  at System.Threading.Tasks.Task.Dispose (System.Boolean disposing)
  at System.Threading.Tasks.Task.Dispose ()
  at Buttplug.Client.ButtplugWebsocketConnector.RunClientLoop (System.Threading.CancellationToken token) in Buttplug/Client/ButtplugWebsocketConnector.cs:135
```

This results in the `ButtplugClient.ServerDisconnect` event not being raised.

---

I think the Dispose was meant to set the task to "fire-and-forget". That can be achieved by just discarding the return value.

According to <https://devblogs.microsoft.com/dotnet/do-i-need-to-dispose-of-tasks/>, tasks do not need to be disposed anyway.